### PR TITLE
Fixes from Sandia Labs (round 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,18 @@ if (OPENMP_FOUND)
 endif()
 
 # install paths
-set(CMAKE_INSTALL_PREFIX "..")
-set(CMAKE_INSTALL_RPATH "\$ORIGIN/../")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX ".." CACHE PATH "Path where AMGX will be installed" FORCE)
+endif()
+# add CMAKE_INSTALL_PREFIX/lib to the RPATH to be used when installing,
+# but only if it's not a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+     "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # ignore rpath completely, if requested:

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -37,3 +37,8 @@ CUDA_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
 FILE(GLOB_RECURSE SRCS "src/*.cu")
 
 CUDA_ADD_LIBRARY(amgx_base STATIC ${SRCS} ${CMAKE_SOURCE_DIR}/plugin_config.cu)
+
+install(FILES
+  include/amgx_config.h
+  include/amgx_c.h
+  DESTINATION include)

--- a/core/src/version.cu
+++ b/core/src/version.cu
@@ -2,5 +2,5 @@
 namespace amgx{
 const char __AMGX_BUILD_DATE__ [] = __DATE__;
 const char __AMGX_BUILD_TIME__ [] = __TIME__;
-const char __AMGX_BUILD_ID__ [] = "2.0.0-public-build125";
+const char __AMGX_BUILD_ID__ [] = "2.0.0.130-opensource";
 }


### PR DESCRIPTION
These changes mostly allow `CMAKE_INSTALL_PREFIX` to actually install AMGX in an external location, including header files. A few other improvements are mixed in.