### PR TITLE
Update CMakeLists

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -38,7 +38,6 @@ FILE(GLOB_RECURSE SRCS "src/*.cu")
 
 CUDA_ADD_LIBRARY(amgx_base STATIC ${SRCS} ${CMAKE_SOURCE_DIR}/plugin_config.cu)
 
-install(FILES
-  include/amgx_config.h
-  include/amgx_c.h
+install(DIRECTORY
+  include/
   DESTINATION include)


### PR DESCRIPTION
I am suggesting this minor change to the CMakeLists.txt file due to the limitations wexisting in the current C API for the eigensolvers. The limitation is the following:
    
 - The eigenvalues and eigenvectors cannot be accessed through the existing eigen C-API. See issue https://github.com/NVIDIA/AMGX/issues/37 for more details pertaining to this limitation.
    
Therefore, the make install command should include the full base/include directory since I am accessing AMGX specific code that is not wrapped through the existing eigen C-API.