### PR TITLE
Add AMGX_matrix_upload_distributed and related API for partition offsets

### DIFF
--- a/ReleaseVersion.txt
+++ b/ReleaseVersion.txt
@@ -1,1 +1,1 @@
-"2.0.0.130-opensource"
+"2.1.0.131-opensource"

--- a/base/include/amgx_c.h
+++ b/base/include/amgx_c.h
@@ -133,6 +133,10 @@ typedef AMGX_vector_handle_struct *AMGX_vector_handle;
 typedef struct {char AMGX_solver_handle_dummy;} AMGX_solver_handle_struct;
 typedef AMGX_solver_handle_struct *AMGX_solver_handle;
 
+typedef struct {char AMGX_distribution_handle_dummy;} AMGX_distribution_handle_struct;
+/** Stores parameters about global matrix distribution and upload */
+typedef AMGX_distribution_handle_struct *AMGX_distribution_handle;
+
 
 /*********************************************************
  * Print C-API error and exit
@@ -238,6 +242,13 @@ AMGX_RC AMGX_API AMGX_resources_create_simple
 
 AMGX_RC AMGX_API AMGX_resources_destroy
 (AMGX_resources_handle rsc);
+
+/* Distribution */
+AMGX_RC AMGX_API AMGX_matrixdist_create
+(AMGX_distribution_handle *dist);
+
+AMGX_RC AMGX_API AMGX_matrixdist_destroy
+(AMGX_distribution_handle dist);
 
 /* Matrix */
 AMGX_RC AMGX_API AMGX_matrix_create
@@ -537,7 +548,7 @@ AMGX_RC AMGX_API AMGX_matrix_upload_all_global
  int allocated_halo_depth,
  int num_import_rings,
  const int *partition_vector);
-
+ 
 AMGX_RC AMGX_API AMGX_matrix_upload_all_global_32
 (AMGX_matrix_handle mtx,
  int n_global,
@@ -553,6 +564,18 @@ AMGX_RC AMGX_API AMGX_matrix_upload_all_global_32
  int num_import_rings,
  const int *partition_vector);
 
+ AMGX_RC AMGX_API AMGX_matrix_upload_distributed
+(AMGX_matrix_handle mtx,
+ int n_global,
+ int n,
+ int nnz,
+ int block_dimx,
+ int block_dimy,
+ const int *row_ptrs,
+ const void *col_indices_global,
+ const void *data,
+ const void *diag_data,
+ AMGX_distribution_handle distribution);
 
 /*********************************************************
  * C-API deprecated

--- a/base/include/amgx_c.h
+++ b/base/include/amgx_c.h
@@ -114,6 +114,15 @@ typedef enum
 } AMGX_GET_PARAMS_DESC_FLAG;
 
 /*********************************************************
+ * Flags to determine behavior of distributed matrix partitioning
+ *********************************************************/
+typedef enum
+{
+    AMGX_DIST_PARTITION_VECTOR = 0,
+    AMGX_DIST_PARTITION_OFFSETS = 1,
+} AMGX_DIST_PARTITION_INFO;
+
+/*********************************************************
  * Forward (opaque) handle declaration
  *********************************************************/
 typedef void (*AMGX_print_callback)(const char *msg, int length);
@@ -252,20 +261,25 @@ AMGX_RC AMGX_API AMGX_distribution_create
 AMGX_RC AMGX_API AMGX_distribution_destroy
 (AMGX_distribution_handle dist);
 
-/** For a contiguous partitioning, set the offsets to allow faster matrix upload.
+/** Set the partitioning scheme used for the matrix.
  * 
- * `offsets` can be `int` or `int64_t` array. It must match the column index data type.
+ * AMGX_DIST_PARTITION_VECTOR:
+ *  Pass in a partition vector of type `int` for `partition_data` with the same format as for AMGX_matrix_upload_all_global().
+ * AMGX_DIST_PARTITION_OFFSETS:
+ *  For a contiguous partitioning, specifying the offsets allows faster matrix upload.
+ *  In this case, `partition_data` must be `int` or `int64_t` array, matching the column index data type.
+ * 
  * Use with \see AMGX_matrix_upload_distributed()
 */
-AMGX_RC AMGX_API AMGX_distribution_set_partition_offsets
-(AMGX_distribution_handle dist, const void *offsets);
+AMGX_RC AMGX_API AMGX_distribution_set_partition_data
+(AMGX_distribution_handle dist, AMGX_DIST_PARTITION_INFO info, const void *partition_data);
 
-/** Set a partition vector with the same format as for AMGX_matrix_upload_all_global()
+/** Set whether to use 32-bit or 64-bit column indices. Default is 64 bit.
  * 
- * Use with \see AMGX_matrix_upload_distributed()
+ * Determines how the `col_indices_global` argument to AMGX_matrix_upload_distributed() is interpreted.
  */
-AMGX_RC AMGX_API AMGX_distribution_set_partition_vector
-(AMGX_distribution_handle dist, const int *partition_vector);
+AMGX_RC AMGX_API AMGX_distribution_set_32bit_colindices
+(AMGX_distribution_handle dist, int use32bit);
 
 /* Matrix */
 AMGX_RC AMGX_API AMGX_matrix_create

--- a/base/include/amgx_c.h
+++ b/base/include/amgx_c.h
@@ -244,11 +244,26 @@ AMGX_RC AMGX_API AMGX_resources_destroy
 (AMGX_resources_handle rsc);
 
 /* Distribution */
-AMGX_RC AMGX_API AMGX_matrixdist_create
+AMGX_RC AMGX_API AMGX_distribution_create
 (AMGX_distribution_handle *dist);
 
-AMGX_RC AMGX_API AMGX_matrixdist_destroy
+AMGX_RC AMGX_API AMGX_distribution_destroy
 (AMGX_distribution_handle dist);
+
+/** For a contiguous partitioning, set the offsets to allow faster matrix upload.
+ * 
+ * `offsets` can be `int` or `int64_t` array. It must match the column index data type.
+ * Use with \see AMGX_matrix_upload_distributed()
+*/
+AMGX_RC AMGX_API AMGX_distribution_set_partition_offsets
+(AMGX_distribution_handle dist, const void *offsets);
+
+/** Set a partition vector with the same format as for AMGX_matrix_upload_all_global()
+ * 
+ * Use with \see AMGX_matrix_upload_distributed()
+ */
+AMGX_RC AMGX_API AMGX_distribution_set_partition_vector
+(AMGX_distribution_handle dist, const int *partition_vector);
 
 /* Matrix */
 AMGX_RC AMGX_API AMGX_matrix_create

--- a/base/include/amgx_c.h
+++ b/base/include/amgx_c.h
@@ -244,8 +244,10 @@ AMGX_RC AMGX_API AMGX_resources_destroy
 (AMGX_resources_handle rsc);
 
 /* Distribution */
+/** Create a distribution handle.
+ * `cfg` is used to set parameters from an existing configuration. Can be null. */
 AMGX_RC AMGX_API AMGX_distribution_create
-(AMGX_distribution_handle *dist);
+(AMGX_distribution_handle *dist, AMGX_config_handle cfg);
 
 AMGX_RC AMGX_API AMGX_distribution_destroy
 (AMGX_distribution_handle dist);

--- a/base/include/amgx_c.h
+++ b/base/include/amgx_c.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/base/include/distributed/distributed_manager.h
+++ b/base/include/distributed/distributed_manager.h
@@ -2053,6 +2053,15 @@ class DistributedManager< TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         friend class CommsMPIDirect<TConfig_h>;
         friend class CommsSingleDeviceBase<TConfig_d>;
         friend class CommsSingleDeviceBase<TConfig_h>;
+    private:
+        template <typename t_ColIndex>
+        void loadDistributed_SetOffsets(int num_ranks, int num_rows_global, const t_ColIndex* partition_offsets);
+
+        template <typename t_ColIndex>
+        std::map<t_ColIndex, int> loadDistributed_LocalToGlobal(int num_rows, I64Vector_h &off_diag_cols);
+
+        void loadDistributed_InitLocalMatrix(IVector_h local_col_indices, int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy,
+            const int *row_offsets, const mat_value_type *values, const void *diag);
 };
 }
 

--- a/base/include/distributed/distributed_manager.h
+++ b/base/include/distributed/distributed_manager.h
@@ -1810,8 +1810,8 @@ class DistributedManager< TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indP
         void unpack_partition(index_type *Bp, index_type *Bc, mat_value_type *Bv);
 
         void generatePoisson7pt(int nx, int ny, int nz, int P, int Q, int R);
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const int *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag);
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const int64_t *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
+        template <typename t_ColIndex>
+        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_ColIndex *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
         void renumberMatrixOneRing(int update_neighbours = 0);
         void renumber_P_R(Matrix<TConfig_h> &P, Matrix<TConfig_h> &R, Matrix<TConfig_h> &A);
         void createOneRingB2Lmaps();
@@ -1943,8 +1943,8 @@ class DistributedManager< TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         void unpack_partition(index_type *Bp, index_type *Bc, mat_value_type *Bv);
 
         void generatePoisson7pt(int nx, int ny, int nz, int P, int Q, int R);
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const int *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag);
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const int64_t *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
+        template <typename t_ColIndex>
+        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_ColIndex *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
         void renumberMatrixOneRing(int update_neighbours = 0);
         void renumber_P_R(Matrix<TConfig_d> &P, Matrix<TConfig_d> &R, Matrix<TConfig_d> &A);
         void createOneRingB2Lmaps();

--- a/base/include/distributed/distributed_manager.h
+++ b/base/include/distributed/distributed_manager.h
@@ -61,6 +61,7 @@ template <class TConfig> class Energymin_AMG_Level_Base;
 #include <ld_functions.h>
 #include <distributed/distributed_comms.h>
 #include <distributed/distributed_arranger.h>
+#include <matrix_distribution.h>
 
 #include "amgx_types/math.h"
 #include "amgx_types/util.h"
@@ -1810,8 +1811,8 @@ class DistributedManager< TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indP
         void unpack_partition(index_type *Bp, index_type *Bc, mat_value_type *Bv);
 
         void generatePoisson7pt(int nx, int ny, int nz, int P, int Q, int R);
-        template <typename t_ColIndex>
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_ColIndex *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
+        template <typename t_colIndex>
+        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_colIndex *col_indices, const mat_value_type *values, int num_ranks, int num_rows_global, const void *diag_data, const MatrixDistribution &dist);
         void renumberMatrixOneRing(int update_neighbours = 0);
         void renumber_P_R(Matrix<TConfig_h> &P, Matrix<TConfig_h> &R, Matrix<TConfig_h> &A);
         void createOneRingB2Lmaps();
@@ -1943,8 +1944,8 @@ class DistributedManager< TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         void unpack_partition(index_type *Bp, index_type *Bc, mat_value_type *Bv);
 
         void generatePoisson7pt(int nx, int ny, int nz, int P, int Q, int R);
-        template <typename t_ColIndex>
-        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_ColIndex *col_indices, const mat_value_type *values, int num_ranks, const int *partition, int num_rows_global, const void *diag_data);
+        template <typename t_colIndex>
+        void loadDistributedMatrix(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, const int *row_offsets, const t_colIndex *col_indices, const mat_value_type *values, int num_ranks, int num_rows_global, const void *diag_data, const MatrixDistribution &dist);
         void renumberMatrixOneRing(int update_neighbours = 0);
         void renumber_P_R(Matrix<TConfig_d> &P, Matrix<TConfig_d> &R, Matrix<TConfig_d> &A);
         void createOneRingB2Lmaps();
@@ -2054,14 +2055,22 @@ class DistributedManager< TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         friend class CommsSingleDeviceBase<TConfig_d>;
         friend class CommsSingleDeviceBase<TConfig_h>;
     private:
-        template <typename t_ColIndex>
-        void loadDistributed_SetOffsets(int num_ranks, int num_rows_global, const t_ColIndex* partition_offsets);
+        template <typename t_colIndex>
+        void loadDistributed_SetOffsets(int num_ranks, int num_rows_global, const t_colIndex* partition_offsets);
 
-        template <typename t_ColIndex>
-        std::map<t_ColIndex, int> loadDistributed_LocalToGlobal(int num_rows, I64Vector_h &off_diag_cols);
+        template <typename t_colIndex>
+        std::map<t_colIndex, int> loadDistributed_LocalToGlobal(int num_rows, I64Vector_h &off_diag_cols);
 
         void loadDistributed_InitLocalMatrix(IVector_h local_col_indices, int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy,
             const int *row_offsets, const mat_value_type *values, const void *diag);
+
+        template <typename t_colIndex>
+        void loadDistributedMatrixPartitionVec(int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, 
+            const int *row_offsets, const t_colIndex *col_indices, const mat_value_type *values, int num_ranks, int num_rows_global, const void *diag, const int *partition);
+
+        template <typename t_colIndex>
+        void loadDistributedMatrixPartitionOffsets( int num_rows, int num_nonzeros, const int block_dimx, const int block_dimy, 
+            const int *row_offsets, const t_colIndex *col_indices, const mat_value_type *values, int num_ranks, int num_rows_global, const void *diag, const t_colIndex *partition_offsets);
 };
 }
 

--- a/base/include/distributed/distributed_manager.h
+++ b/base/include/distributed/distributed_manager.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/base/include/distributed/glue.h
+++ b/base/include/distributed/glue.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/base/include/distributed/glue.h
+++ b/base/include/distributed/glue.h
@@ -33,6 +33,7 @@
 #include <types.h>
 #include <norm.h>
 #include <logger.h>
+#include <matrix_distribution.h>
 
 #include <iostream>
 #include <iomanip>
@@ -504,7 +505,9 @@ int upload_matrix_after_glue(int n, int nnz, int *r_ptr, int *i_ptr, void *v_ptr
     nv_mtx.set_initialized(0);
     nv_mtx.delProps(DIAG);
     // Load distributed matrix
-    nv_mtx.manager->loadDistributedMatrix(n, nnz, block_dimx, block_dimy, r_ptr, i_ptr, (t_MatPrec *) v_ptr, num_ranks, part_vec_ptr, n_global, NULL);
+    MatrixDistribution mdist;
+    mdist.setPartitionVec(part_vec_ptr);
+    nv_mtx.manager->loadDistributedMatrix(n, nnz, block_dimx, block_dimy, r_ptr, i_ptr, (t_MatPrec *) v_ptr, num_ranks, n_global, NULL, mdist);
     // Create B2L_maps for comm
     nv_mtx.manager->renumberMatrixOneRing();
     // WARNING WE SHOULD GET THE NUMBER OF RINGS AND DO THE FOLLOWING ONLY IF THERE ARE 2 RINGS

--- a/base/include/matrix_distribution.h
+++ b/base/include/matrix_distribution.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2019, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/base/include/matrix_distribution.h
+++ b/base/include/matrix_distribution.h
@@ -64,13 +64,9 @@ public:
     PartitionInformation getPartitionInformationStyle() const { return m_partition_information; }
     void setPartitionVec(const int* partition_vector) 
     {
-        if (partition_vector != nullptr) {
-            m_partition_information = PartitionInformation::PartitionVec;
-            m_partition_data = partition_vector;
-        }
-        else {
-            FatalError("partition_vector cannot be NULL", AMGX_ERR_BAD_PARAMETERS);
-        }
+        // Setting a "NULL" partition vector is valid, as the  upload routine will generate one in that case
+        m_partition_information = PartitionInformation::PartitionVec;
+        m_partition_data = partition_vector;
     }
     void setPartitionOffsets(const void* partition_offsets)
     {

--- a/base/include/matrix_distribution.h
+++ b/base/include/matrix_distribution.h
@@ -27,23 +27,31 @@
 
 #pragma once
 
+#include <error.h>
+
 namespace amgx {
 /** Transports parameters for matrix_upload_distributed() call. */
 class MatrixDistribution 
 {
+public:
+    enum class PartitionInformation {
+        None,
+        PartitionVec,
+        PartitionOffsets
+    };
 private:
     int m_allocated_halo_depth;
     int m_num_import_rings;
-    bool m_has_full_partition_vec;
+    PartitionInformation m_partition_information;
     bool m_has_32bit_col_indices;
-    const int *m_partition_vector;
+    const void *m_partition_data;
 public:
     MatrixDistribution() :
         m_allocated_halo_depth(1),
         m_num_import_rings(1),
-        m_has_full_partition_vec(false),
+        m_partition_information(PartitionInformation::None),
         m_has_32bit_col_indices(false),
-        m_partition_vector(nullptr) {};
+        m_partition_data(nullptr) {};
     void setNumImportRings(int num_import_rings) { m_num_import_rings = num_import_rings; }
     int getNumImportRings() const { return m_num_import_rings; }
 
@@ -53,14 +61,28 @@ public:
     void set32BitColIndices(bool use32bit) { m_has_32bit_col_indices = use32bit; }
     int get32BitColIndices() const { return m_has_32bit_col_indices; }
 
-    void setExplicitPartitionVec(const int* partition_vector) 
+    PartitionInformation getPartitionInformationStyle() const { return m_partition_information; }
+    void setPartitionVec(const int* partition_vector) 
     {
         if (partition_vector != nullptr) {
-            m_has_full_partition_vec = true;
-            m_partition_vector = partition_vector;
+            m_partition_information = PartitionInformation::PartitionVec;
+            m_partition_data = partition_vector;
+        }
+        else {
+            FatalError("partition_vector cannot be NULL", AMGX_ERR_BAD_PARAMETERS);
         }
     }
-    const int* getPartitionVec() const { return m_partition_vector; }
+    void setPartitionOffsets(const void* partition_offsets)
+    {
+        if (partition_offsets != nullptr) {
+            m_partition_information = PartitionInformation::PartitionOffsets;
+            m_partition_data = partition_offsets;
+        }
+        else {
+            FatalError("partition_offsets cannot be NULL", AMGX_ERR_BAD_PARAMETERS);
+        }
+    }
+    const void* getPartitionData() const { return m_partition_data; }
 };
 
 } // namespace amgx

--- a/base/include/matrix_distribution.h
+++ b/base/include/matrix_distribution.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2013-2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace amgx {
+/** Transports parameters for matrix_upload_distributed() call. */
+class MatrixDistribution 
+{
+private:
+    int m_allocated_halo_depth;
+    int m_num_import_rings;
+    bool m_has_full_partition_vec;
+    const int *m_partition_vector;
+public:
+    MatrixDistribution() :
+        m_allocated_halo_depth(1),
+        m_num_import_rings(1),
+        m_has_full_partition_vec(false),
+        m_partition_vector(nullptr) {};
+    void setNumImportRings(int num_import_rings) { m_num_import_rings = num_import_rings; }
+    int getNumImportRings() const { return m_num_import_rings; }
+
+    void setAllocatedHaloDepth(int allocated_halo_depth) { m_allocated_halo_depth = allocated_halo_depth; }
+    int getAlllocatedHaloDepth() const { return m_allocated_halo_depth; }
+
+    void setExplicitPartitionVec(const int* partition_vector) 
+    {
+        if (partition_vector != nullptr) {
+            m_has_full_partition_vec = true;
+            m_partition_vector = partition_vector;
+        }
+    }
+    const int* getPartitionVec() const { return m_partition_vector; }
+};
+
+} // namespace amgx

--- a/base/include/matrix_distribution.h
+++ b/base/include/matrix_distribution.h
@@ -35,18 +35,23 @@ private:
     int m_allocated_halo_depth;
     int m_num_import_rings;
     bool m_has_full_partition_vec;
+    bool m_has_32bit_col_indices;
     const int *m_partition_vector;
 public:
     MatrixDistribution() :
         m_allocated_halo_depth(1),
         m_num_import_rings(1),
         m_has_full_partition_vec(false),
+        m_has_32bit_col_indices(false),
         m_partition_vector(nullptr) {};
     void setNumImportRings(int num_import_rings) { m_num_import_rings = num_import_rings; }
     int getNumImportRings() const { return m_num_import_rings; }
 
     void setAllocatedHaloDepth(int allocated_halo_depth) { m_allocated_halo_depth = allocated_halo_depth; }
     int getAlllocatedHaloDepth() const { return m_allocated_halo_depth; }
+
+    void set32BitColIndices(bool use32bit) { m_has_32bit_col_indices = use32bit; }
+    int get32BitColIndices() const { return m_has_32bit_col_indices; }
 
     void setExplicitPartitionVec(const int* partition_vector) 
     {

--- a/base/src/amgx_c.cu
+++ b/base/src/amgx_c.cu
@@ -4712,29 +4712,40 @@ extern "C" {
         return AMGX_RC_OK;
     }
 
-    AMGX_RC AMGX_API AMGX_distribution_set_partition_offsets(AMGX_distribution_handle dist, const void *offsets)
+    AMGX_RC AMGX_API AMGX_distribution_set_partition_data(AMGX_distribution_handle dist, AMGX_DIST_PARTITION_INFO info, const void *partition_data)
     {
-        if (dist == NULL || offsets == NULL) 
+        if (dist == NULL || partition_data == NULL) 
         {
             AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_PARAMETERS, NULL);
         }
         typedef CWrapHandle<AMGX_distribution_handle, MatrixDistribution> MatrixDistributionW;
         MatrixDistributionW wrapDist(dist);
         MatrixDistribution &mdist = *wrapDist.wrapped();
-        mdist.setPartitionOffsets(offsets);
+        switch (info)
+        {
+            case AMGX_DIST_PARTITION_VECTOR:
+                mdist.setPartitionVec((const int*)partition_data);
+                break;
+            case AMGX_DIST_PARTITION_OFFSETS:
+                mdist.setPartitionOffsets(partition_data);
+                break;
+            default:
+                AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_PARAMETERS, NULL);
+                break;
+        }
         return AMGX_RC_OK;
     }
 
-    AMGX_RC AMGX_API AMGX_distribution_set_partition_vector(AMGX_distribution_handle dist, const int *partition_vector)
+    AMGX_RC AMGX_API AMGX_distribution_set_32bit_colindices(AMGX_distribution_handle dist, int use32bit)
     {
-        if (dist == NULL || partition_vector == NULL) 
+        if (dist == NULL)
         {
             AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_PARAMETERS, NULL);
         }
         typedef CWrapHandle<AMGX_distribution_handle, MatrixDistribution> MatrixDistributionW;
         MatrixDistributionW wrapDist(dist);
         MatrixDistribution &mdist = *wrapDist.wrapped();
-        mdist.setPartitionVec(partition_vector);
+        mdist.set32BitColIndices(use32bit);
         return AMGX_RC_OK;
     }
 

--- a/base/src/amgx_c.cu
+++ b/base/src/amgx_c.cu
@@ -1792,7 +1792,7 @@ inline AMGX_RC matrix_upload_all_global(AMGX_matrix_handle mtx,
                                         const int *partition_vector)
 {
     AMGX_distribution_handle dist;
-    AMGX_distribution_create(&dist);
+    AMGX_distribution_create(&dist, NULL);
     MatrixDistributionW wrapDist(dist);
     MatrixDistribution &mdist = *wrapDist.wrapped();
     mdist.setPartitionVec(partition_vector);
@@ -1819,7 +1819,7 @@ inline AMGX_RC matrix_upload_all_global_32(AMGX_matrix_handle mtx,
                                            const int *partition_vector)
 {
     AMGX_distribution_handle dist;
-    AMGX_distribution_create(&dist);
+    AMGX_distribution_create(&dist, NULL);
     MatrixDistributionW wrapDist(dist);
     MatrixDistribution &mdist = *wrapDist.wrapped();
     mdist.setPartitionVec(partition_vector);
@@ -4672,12 +4672,19 @@ extern "C" {
         return AMGX_RC_OK;
     }
 
-    AMGX_RC AMGX_API AMGX_distribution_create(AMGX_distribution_handle *dist)
+    AMGX_RC AMGX_API AMGX_distribution_create(AMGX_distribution_handle *dist, AMGX_config_handle cfg)
     {
         AMGX_ERROR rc = AMGX_OK;
         try 
         {
             auto *mdist = create_managed_object<MatrixDistribution, AMGX_distribution_handle>(dist);
+            if (cfg != NULL)
+            {
+                int ring;
+                rc = getAMGXerror(AMGX_config_get_default_number_of_rings(cfg, &ring));
+                mdist->wrapped()->setAllocatedHaloDepth(ring);
+                mdist->wrapped()->setNumImportRings(ring);
+            }
         }
         AMGX_CATCHES(rc);
         if (rc != AMGX_OK)

--- a/base/src/amgx_c.cu
+++ b/base/src/amgx_c.cu
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/base/src/distributed/distributed_manager.cu
+++ b/base/src/distributed/distributed_manager.cu
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/examples/amgx_capi.h
+++ b/examples/amgx_capi.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/examples/amgx_mpi_capi_cla.c
+++ b/examples/amgx_mpi_capi_cla.c
@@ -494,9 +494,33 @@ int main(int argc, char **argv)
 
     /* compute global number of rows */
     int nglobal;
-    MPI_Allreduce(&n, &nglobal, 1, MPI_INT, MPI_SUM, amgx_mpi_comm);
     /* upload the matrix with global indices and compute necessary connectivity information */
-    AMGX_matrix_upload_all_global(A, nglobal, n, nnz, block_dimx, block_dimy, row_ptrs, col_indices, values, diag, nrings, nrings, partition_vector);
+    if (partition_vector == NULL) 
+    {
+        // If no partition vector is given, we assume a partitioning with contiguous blocks (see example above). It is sufficient (and faster/more scalable)
+        // to calculate the partition offsets and pass those into the API call instead of creating a full partition vector.
+        int64_t* partition_offsets = (int64_t*)malloc((nranks+1) * sizeof(int64_t));
+        // gather the number of rows on each rank, and perform an exclusive scan to get the offsets.
+        int64_t n64 = n;
+        partition_offsets[0] = 0; // rows of rank 0 always start at index 0
+        MPI_Allgather(&n64, 1, MPI_INT64_T, &partition_offsets[1], 1, MPI_INT64_T, amgx_mpi_comm);
+        for (int i = 2; i < nranks + 1; ++i) {
+            partition_offsets[i] += partition_offsets[i-1];
+        }
+        nglobal = partition_offsets[nranks]; // last element always has global number of rows
+
+        AMGX_distribution_handle dist;
+        AMGX_distribution_create(&dist, cfg);
+        AMGX_distribution_set_partition_data(dist, AMGX_DIST_PARTITION_OFFSETS, partition_offsets);
+        AMGX_matrix_upload_distributed(A, nglobal, n, nnz, block_dimx, block_dimy, row_ptrs, col_indices, values, diag, dist);
+        AMGX_distribution_destroy(dist);
+        free(partition_offsets);
+    }
+    else 
+    {
+        MPI_Allreduce(&n, &nglobal, 1, MPI_INT, MPI_SUM, amgx_mpi_comm);
+        AMGX_matrix_upload_all_global(A, nglobal, n, nnz, block_dimx, block_dimy, row_ptrs, col_indices, values, diag, nrings, nrings, partition_vector);
+    }
 
     /* free temporary storage */
     if (partition_vector != NULL) { free(partition_vector); }

--- a/examples/amgx_mpi_capi_cla.c
+++ b/examples/amgx_mpi_capi_cla.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2017, NVIDIA CORPORATION. All rights reserved.
+/* Copyright (c) 2011-2019, NVIDIA CORPORATION. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/examples/amgx_spmv_example/amgx_spmv_distributed_internal.cu
+++ b/examples/amgx_spmv_example/amgx_spmv_distributed_internal.cu
@@ -126,7 +126,9 @@ void spmv_example(amgx::Resources& res)
     matrix_values_h.resize(nnz);
     for (auto &v : matrix_values_h) v = ((double)random())/RAND_MAX;
     // Let distributed manager load data into bound matrix structure
-    d_mgr.loadDistributedMatrix(nrows, nnz, 1, 1, &row_offsets_h[0], &column_indices_h[0], &matrix_values_h[0], nranks, &partition_vector[0], n_global, NULL);
+    MatrixDistribution mdist;
+    mdist.setPartitionVec(&partition_vector[0]);
+    d_mgr.loadDistributedMatrix(nrows, nnz, 1, 1, &row_offsets_h[0], &column_indices_h[0], &matrix_values_h[0], nranks, n_global, NULL, mdist);
     // Matrix should be reordered with 1 halo ring for SpMV 
     d_mgr.renumberMatrixOneRing();
     // Initializing communicator parameters


### PR DESCRIPTION
This change adds a new entry point `AMGX_matrix_upload_distributed ` and related `AMGX_distribution_...` calls, adding more flexibility in how an MPI-distributed matrix will be uploaded.
The motivation is to take advantage of the case where a matrix with `N` rows is distributed blockwise "contiguously" across `R` ranks, so that rank 0 has rows `0...offsets[1]-1`, rank 1 has rows `offsets[1]..offsets[2]-1`, and so on. The whole partition offset array has size `R+1`, compared to an explicit partition vector of size `N` (with one entry per matrix row). Using the offsets also allows the upload to be more scalable as it only needs to loop over structures that grow with the size of the local matrix portion.