### PR TITLE
fix a compute block inverse bug for Volta new feature

### DIFF
--- a/core/include/solvers/block_common_solver.h
+++ b/core/include/solvers/block_common_solver.h
@@ -378,7 +378,7 @@ ValueType tmp;
                 tmp = s_A2_rval(row, j_ind + t2 * 4) * diag;
                 s_A2_lval(tmp, row, j_ind + t2 * 4);
             }
-
+        __syncwarp();
         for (int t1 = 0; t1 < tile_num; t1++)
             for (int t2 = 0; t2 < tile_num; t2++)
                 if ((i_ind + t1 * 4 != row) && !(j_ind + t2 * 4 == row) && ((t1 * 4 + i_ind) < bsize) && ((t2 * 4 + j_ind) < bsize))
@@ -386,6 +386,7 @@ ValueType tmp;
                     tmp = types::util<ValueType>::invert((s_A2_rval(i_ind + t1 * 4, row) * s_A2_rval(row, j_ind + t2 * 4)) + s_A2_rval(i_ind + t1 * 4, j_ind + t2 * 4));
                     s_A2_lval(tmp, i_ind + t1 * 4, j_ind + t2 * 4);
                 }
+        __syncwarp();
 
         for (int t2 = 0; t2 < tile_num; t2++)
             if (i_ind == 0 && (t2 * 4 + j_ind) < bsize)
@@ -393,6 +394,7 @@ ValueType tmp;
                 tmp = ((j_ind + t2 * 4) == row) ? diag : types::util<ValueType>::invert(s_A2_rval(j_ind + t2 * 4, row) * diag);
                 s_A2_lval(tmp, j_ind + t2 * 4, row)
             }
+        __syncwarp();
     }
 
     for (int t1 = 0; t1 < tile_num; t1++)


### PR DESCRIPTION
      
   Here fix the compute block inverse bug in ./AMGX/core/include/solvers/block_common_solver.h.
 
   The cuda 9.0 introduces Independent Thread Scheduling.   In the "compute_block_inverse2" function have warp-synchronous codes, we need insert __syncwarp().  
 
   Btw a question:  could you tell me the algorithm name below (compute a block inverse)??

```
for (int row = 0; row < bsize; row++)

    {
        diag = isNotCloseToZero( s_A_rval(row, row) ) ? types::util<ValueType>::get_one() / s_A_rval(row, row) : types::util<ValueType>::get_one() / epsilon(s_A_rval(row, row)); 

        if ((i_ind == 0) && !(j_ind == row))
        {
            tmp = s_A_rval(row, j_ind) * diag;
            s_A_lval(tmp, row, j_ind);
        }

        if ((i_ind != row) && !(j_ind == row))
        {
            tmp = types::util<ValueType>::invert(s_A_rval(i_ind, row) * s_A_rval(row, j_ind)) + s_A_rval(i_ind, j_ind);
            s_A_lval(tmp, i_ind, j_ind);
        }

        if (i_ind == 0)
        {
            tmp = (j_ind == row) ? diag : types::util<ValueType>::invert(s_A_rval(j_ind, row) * diag);
            s_A_lval(tmp, j_ind, row);
        }
    }
```