### PR TITLE
Fix for cuSPARSE nnz passing and latency hiding when block size > 1

### DIFF
--- a/base/include/distributed/distributed_manager.h
+++ b/base/include/distributed/distributed_manager.h
@@ -283,7 +283,7 @@ template <typename TConfig> class DistributedManagerBase
 
         DistributedManagerBase() : m_fine_level_comms(NULL), _num_interior_nodes(0), m_pinned_buffer(NULL), m_pinned_buffer_size(0), _num_boundary_nodes(0), _comms(NULL), has_B2L(false),
             neighbors(_neighbors), B2L_maps(_B2L_maps), L2H_maps(_L2H_maps),  B2L_rings(_B2L_rings),
-            halo_ranges(_halo_ranges), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),  halo_rows(NULL), halo_btl(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            halo_ranges(_halo_ranges), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),  halo_rows(NULL), halo_btl(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
 
         {
             cudaEventCreate(&comm_event);
@@ -302,7 +302,7 @@ template <typename TConfig> class DistributedManagerBase
             neighbors(_neighbors), halo_offsets(halo_offsets_),
             B2L_maps(_B2L_maps),   L2H_maps(_L2H_maps), B2L_rings(_B2L_rings),
             halo_ranges(_halo_ranges), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h), halo_rows(NULL), halo_btl(NULL),
-            _comms(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            _comms(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -327,7 +327,7 @@ template <typename TConfig> class DistributedManagerBase
                                 std::vector<std::vector<VecInt_t> > &B2L_rings_,
                                 DistributedComms<TConfig> **comms_,
                                 std::vector<Matrix<TConfig> > **halo_rows_,
-                                std::vector<DistributedManager<TConfig> > **halo_btl_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), B2L_maps(B2L_maps_), L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(halo_ranges_), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h)
+                                std::vector<DistributedManager<TConfig> > **halo_btl_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), B2L_maps(B2L_maps_), L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(halo_ranges_), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -344,7 +344,7 @@ template <typename TConfig> class DistributedManagerBase
                                 std::vector<std::vector<VecInt_t> > &B2L_rings_,
                                 DistributedComms<TConfig> **comms_,
                                 std::vector<Matrix<TConfig> > **halo_rows_,
-                                std::vector<DistributedManager<TConfig> > **halo_btl_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), B2L_maps(B2L_maps_), L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(halo_ranges_), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h)
+                                std::vector<DistributedManager<TConfig> > **halo_btl_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), B2L_maps(B2L_maps_), L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(halo_ranges_), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -360,7 +360,7 @@ template <typename TConfig> class DistributedManagerBase
                                 std::vector<std::vector<VecInt_t> > &B2L_rings_,
                                 DistributedComms<TConfig> **comms_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), halo_ranges(halo_ranges_),
             halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),
-            B2L_maps(B2L_maps_),  L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            B2L_maps(B2L_maps_),  L2H_maps(_L2H_maps), B2L_rings(B2L_rings_), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -379,7 +379,7 @@ template <typename TConfig> class DistributedManagerBase
                                 std::vector<IVector > &L2H_maps_,
                                 DistributedComms<TConfig> **comms_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), halo_ranges(_halo_ranges),
             halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),
-            B2L_maps(B2L_maps_),  L2H_maps(L2H_maps_), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            B2L_maps(B2L_maps_),  L2H_maps(L2H_maps_), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -426,7 +426,7 @@ template <typename TConfig> class DistributedManagerBase
                                 Vector<ivec_value_type_h> &neighbors_,
                                 I64Vector_h &halo_ranges_h_,
                                 DistributedComms<TConfig> **comms_) : m_fine_level_comms(NULL), _comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(neighbors_), halo_ranges(_halo_ranges), halo_ranges_h(halo_ranges_h_), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),
-            B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -444,7 +444,7 @@ template <typename TConfig> class DistributedManagerBase
                                 const VecInt_t *neighbor_bases,
                                 const VecInt_t *neighbor_sizes,
                                 int num_neighbors) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), neighbors(_neighbors), halo_ranges(_halo_ranges), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),
-            B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+            B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
         {
             cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
             cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);
@@ -1705,6 +1705,7 @@ template <typename TConfig> class DistributedManagerBase
         INDEX_TYPE _num_nz_full;
         INDEX_TYPE _num_rows_all;
         INDEX_TYPE _num_nz_all;
+        bool m_fixed_view_size;
 
         //Containers for Level 0 API:
         std::vector<IVector >_B2L_maps;
@@ -1772,6 +1773,23 @@ template <typename TConfig> class DistributedManagerBase
             }
         }
 
+        // Manually set the view sizes
+        inline void setViewSizes(int num_interior_nodes, int num_nz_interior, int num_rows_owned, int num_nz_owned, int num_rows_full, int num_nz_full, int num_rows_all, int num_nz_all)
+        {
+            this->_num_rows_interior = num_interior_nodes;
+            this->_num_nz_interior = num_nz_interior;
+            this->_num_rows_owned = num_rows_owned;
+            this->_num_nz_owned = num_nz_owned;
+            this->_num_rows_full = num_rows_full;
+            this->_num_nz_full = num_nz_full;
+            this->_num_rows_all = num_rows_all;
+            this->_num_nz_all = num_nz_all;
+
+            // Avoids the view sizes being overwritten by set_initialized
+            this->m_fixed_view_size = true;
+        }
+
+        inline bool isViewSizeFixed() { return this->m_fixed_view_size; }
 
 };
 

--- a/base/include/matrix.h
+++ b/base/include/matrix.h
@@ -971,14 +971,23 @@ class MatrixBase : public AuxData, public Operator<T_Config>
                 {
                     *nnz = 0;
                 }
-
                 return;
             }
 
             manager->getNnzForView(type, nnz);
         }
 
+        // Get the offset, nrows, and nnz for this view
+        inline void getFixedSizesForView(ViewType type, int *offset, int *nrows, int* nnz) const
+        {
+            if(!is_matrix_distributed() || !manager->isViewSizeFixed())
+            {
+                FatalError("getFixedSizesForView should not be called by a non-distributed matrix", AMGX_ERR_INTERNAL);
+            }
 
+            manager->getOffsetAndSizeForView(type, offset, nrows);
+            manager->getNnzForView(type, nnz);
+        }
 
         inline void setManager(DistributedManager<T_Config> &manager_)
         {

--- a/base/src/amgx_cusparse.cu
+++ b/base/src/amgx_cusparse.cu
@@ -41,9 +41,6 @@
 namespace amgx
 {
 
-// global CUSPARSE handle for AMGX
-// Cusparse cusparse;
-
 Cusparse::Cusparse() : m_handle(0)
 {
     cusparseCheckError( cusparseCreate(&m_handle) );
@@ -127,7 +124,7 @@ void Cusparse::bsrmv(
     }
     else
     {
-        if (!A.is_matrix_singleGPU())
+        if (!A.is_matrix_singleGPU() && x.dirtybit != 0)
         {
             A.manager->exchange_halo_v2(x, x.tag);
         }
@@ -173,7 +170,7 @@ void Cusparse::bsrmv_with_mask(
     }
     else
     {
-        if (!A.is_matrix_singleGPU())
+        if (!A.is_matrix_singleGPU() && x.dirtybit != 0)
         {
             A.manager->exchange_halo_v2(x, x.tag);
         }
@@ -205,12 +202,12 @@ void Cusparse::bsrmv_with_mask_restriction(
     bool latencyHiding = (R.getViewInterior() != R.getViewExterior() && !P.is_matrix_singleGPU() && x.dirtybit != 0);
 
     if (latencyHiding)
-	  {
+    {
         cudaStream_t null_stream = 0;
-		    bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, HALO1, null_stream, P);
+        bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, HALO1, null_stream, P);
         P.manager->add_from_halo_split_gather(y, y.tag);
-		    cudaEventRecord(P.manager->get_comm_event());
-		    bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, OWNED, null_stream, P);
+        cudaEventRecord(P.manager->get_comm_event());
+        bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, OWNED, null_stream, P);
 
         if (P.manager->neighbors.size() != 0)
         {
@@ -555,10 +552,8 @@ void Cusparse::bsrmv_internal( const typename TConfig::VecPrec alphaConst,
                                const cudaStream_t &stream)
 {
     typedef typename TConfig::VecPrec ValueTypeB;
-    int offset, size;
+    int offset, size, nnz;
     A.getOffsetAndSizeForView(view, &offset, &size);
-
-    int nnz;
     A.getNnzForView(view, &nnz);
 
     cusparseDirection_t direction = CUSPARSE_DIRECTION_COLUMN;
@@ -568,11 +563,10 @@ void Cusparse::bsrmv_internal( const typename TConfig::VecPrec alphaConst,
         direction = CUSPARSE_DIRECTION_ROW;
     }
 
-    bool has_offdiag = A.get_num_nz() != 0;
+    bool has_offdiag = nnz != 0;
 
     if (has_offdiag )
     {
-
         cusparseSetStream(Cusparse::get_instance().m_handle, stream);
         bsrmv( Cusparse::get_instance().m_handle,  direction, CUSPARSE_OPERATION_NON_TRANSPOSE,
                size, A.get_num_cols(), nnz, &alphaConst,
@@ -629,6 +623,11 @@ void Cusparse::bsrmv_internal_with_mask( const typename TConfig::VecPrec alphaCo
         FatalError("Should not be here in bsrmv_internal_with_mask", AMGX_ERR_NOT_IMPLEMENTED);
     }
 
+    if(view != INTERIOR && view != BOUNDARY)
+    {
+        FatalError("Only INTERIOR and BOUNDARY views supported for bsrmv_internal_with_mask", AMGX_ERR_NOT_IMPLEMENTED);
+    }
+
     typedef typename TConfig::VecPrec ValueType;
     cusparseDirection_t direction = CUSPARSE_DIRECTION_COLUMN;
 
@@ -637,26 +636,26 @@ void Cusparse::bsrmv_internal_with_mask( const typename TConfig::VecPrec alphaCo
         direction = CUSPARSE_DIRECTION_ROW;
     }
 
-    bool has_offdiag = A.get_num_nz() != 0;
-
     const int *start_offsets, *end_offsets;
     start_offsets = A.row_offsets.raw();
     end_offsets = A.row_offsets.raw() + 1;
     typedef typename Matrix<TConfig>::index_type index_type;
 
-    // num rows to
-    index_type NumRows = A.manager->getRowsListForView(view).size();
+    int offset, nrows, nnz;
+    A.getFixedSizesForView(view, &offset, &nrows, &nnz);
 
-    if (NumRows <= 0)
+    if (nrows <= 0)
     {
         return;    // nothing to do, early exit
     }
 
-    if (has_offdiag )
+    bool has_offdiag = nnz != 0;
+
+    if (has_offdiag)
     {
         cusparseSetStream(Cusparse::get_instance().m_handle, stream);
-        bsrxmv_internal( Cusparse::get_instance().m_handle, direction, CUSPARSE_OPERATION_NON_TRANSPOSE, NumRows,
-                         A.get_num_rows(), A.get_num_cols(), A.get_num_nz(), &alphaConst,
+        bsrxmv_internal( Cusparse::get_instance().m_handle, direction, CUSPARSE_OPERATION_NON_TRANSPOSE, nrows,
+                         A.get_num_rows(), A.get_num_cols(), nnz, &alphaConst,
                          A.cuMatDescr,
                          A.values.raw(),
                          A.manager->getRowsListForView(view).raw(),
@@ -678,7 +677,7 @@ void Cusparse::bsrmv_internal_with_mask( const typename TConfig::VecPrec alphaCo
 
 template< class TConfig >
 void Cusparse::bsrmv_internal_with_mask_restriction( const typename TConfig::VecPrec alphaConst,
-        const Matrix<TConfig> &A,
+        const Matrix<TConfig> &R,
         const Vector<TConfig> &x,
         const typename TConfig::VecPrec betaConst,
         Vector<TConfig> &y,
@@ -691,58 +690,47 @@ void Cusparse::bsrmv_internal_with_mask_restriction( const typename TConfig::Vec
         FatalError("Should not be here in bsrmv_internal_with_mask_with_restriction", AMGX_ERR_NOT_IMPLEMENTED);
     }
 
-    typedef typename TConfig::VecPrec ValueType;
-    //int offset, size;
-    //A.getOffsetAndSizeForView(view, &offset, &size);
-    cusparseDirection_t direction = CUSPARSE_DIRECTION_COLUMN;
-
-    if ( A.getBlockFormat() == ROW_MAJOR )
-    {
-        direction = CUSPARSE_DIRECTION_ROW;
-    }
-
-    bool has_offdiag = A.get_num_nz() != 0;
-    typedef typename Matrix<TConfig>::index_type index_type;
-    // num rows to
-    int offset, NumRows;
-
-    if (view == OWNED)
-    {
-        NumRows = P.manager->halo_offsets[0];
-        offset = 0;
-    }
-    else if (view == HALO1)
-    {
-        offset = P.manager->halo_offsets[0];
-        NumRows = P.manager->halo_offsets[P.manager->neighbors.size()] - offset;
-    }
-    else
+    if(view != OWNED && view != HALO1)
     {
         FatalError("View not supported in restriction operation", AMGX_ERR_NOT_IMPLEMENTED);
     }
 
-    if (NumRows <= 0)
+    typedef typename TConfig::VecPrec ValueType;
+    cusparseDirection_t direction = CUSPARSE_DIRECTION_COLUMN;
+
+    if ( R.getBlockFormat() == ROW_MAJOR )
+    {
+        direction = CUSPARSE_DIRECTION_ROW;
+    }
+
+    int offset, nrows, nnz;
+    R.getFixedSizesForView(view, &offset, &nrows, &nnz);
+
+    bool has_offdiag = nnz != 0;
+    typedef typename Matrix<TConfig>::index_type index_type;
+
+    if (nrows <= 0)
     {
         return;    // nothing to do, early exit
     }
 
-    if (has_offdiag )
+    if (has_offdiag)
     {
         cusparseSetStream(Cusparse::get_instance().m_handle, stream);
         bsrmv( Cusparse::get_instance().m_handle,  direction, CUSPARSE_OPERATION_NON_TRANSPOSE,
-               NumRows, A.get_num_cols(), A.get_num_nz(), &alphaConst,
-               A.cuMatDescr,
-               A.values.raw(),
-               A.m_seq_offsets.raw() + offset,
-               A.row_offsets.raw() + offset, A.col_indices.raw(),
-               A.get_block_dimx(),
+               nrows, R.get_num_cols(), nnz, &alphaConst,
+               R.cuMatDescr,
+               R.values.raw(),
+               R.m_seq_offsets.raw() + offset,
+               R.row_offsets.raw() + offset, R.col_indices.raw(),
+               R.get_block_dimx(),
                x.raw(), &betaConst,
-               y.raw() + offset * A.get_block_dimx() );
+               y.raw() + offset * R.get_block_dimx() );
         // Reset to default stream
         cusparseSetStream(Cusparse::get_instance().m_handle, 0);
     }
 
-    if (A.hasProps(DIAG))
+    if (R.hasProps(DIAG))
     {
         FatalError("Diag not supported in multiply with mask\n", AMGX_ERR_NOT_IMPLEMENTED);
     }

--- a/base/src/distributed/distributed_manager.cu
+++ b/base/src/distributed/distributed_manager.cu
@@ -836,6 +836,12 @@ void DistributedManagerBase<TConfig>::set_unassigned(IVector_d &partition_flags,
 template <class TConfig >
 inline void DistributedManagerBase<TConfig>::set_initialized(IVector &row_offsets)
 {
+    // For P and R sizes the sizes are fixed at creation
+    if(m_fixed_view_size)
+    {
+        return;
+    }
+
     if (neighbors.size() > 0)
     {
         //distributed: cache num_rows/num_nz for different views
@@ -961,7 +967,7 @@ template <class TConfig>
 inline DistributedManagerBase<TConfig>::DistributedManagerBase(Matrix<TConfig> &a) :
     m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), _num_interior_nodes(0), _num_boundary_nodes(0), _comms(NULL), has_B2L(false),
     neighbors(_neighbors), B2L_maps(_B2L_maps), L2H_maps(_L2H_maps),  B2L_rings(_B2L_rings),
-    halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(_halo_ranges), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h), halo_rows(NULL), halo_btl(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+    halo_rows_ref_count(0), halo_btl_ref_count(0), halo_ranges(_halo_ranges), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h), halo_rows(NULL), halo_btl(NULL), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
 {
     cudaEventCreate(&comm_event);
     cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
@@ -1621,7 +1627,7 @@ inline DistributedManagerBase<TConfig>::DistributedManagerBase(
     INDEX_TYPE num_import_rings,
     int num_neighbors,
     const VecInt_t *neighbors_) : m_fine_level_comms(NULL), A(&a), m_pinned_buffer_size(0), m_pinned_buffer(NULL), _num_interior_nodes(0), _num_boundary_nodes(0), _comms(NULL), has_B2L(false), neighbors(_neighbors), halo_rows_ref_count(0), halo_rows(NULL), halo_btl_ref_count(0), halo_btl(NULL), halo_ranges(_halo_ranges), halo_ranges_h(_halo_ranges_h), part_offsets(_part_offsets), part_offsets_h(_part_offsets_h),
-    B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false)
+    B2L_maps(_B2L_maps),  L2H_maps(_L2H_maps), B2L_rings(_B2L_rings), m_is_root_partition(false), m_is_glued(false), m_is_fine_level_glued(false), m_is_fine_level_consolidated(false), m_is_fine_level_root_partition(false), m_use_cuda_ipc_consolidation(false), m_fixed_view_size(false)
 {
     cudaStreamCreateWithFlags(&m_int_stream, cudaStreamNonBlocking);
     cudaStreamCreateWithFlags(&m_bdy_stream, cudaStreamNonBlocking);

--- a/core/src/classical/classical_amg_level.cu
+++ b/core/src/classical/classical_amg_level.cu
@@ -483,6 +483,17 @@ void Classical_AMG_Level_Base<T_Config>::computeRestrictionOperator()
         R.setExteriorView(OWNED);
     }
 
+    if(P.is_matrix_distributed())
+    {
+        // Setup the number of non-zeros in R using stub DistributedManager
+        R.manager = new DistributedManager<T_Config>();
+        int nrows_owned = P.manager->halo_offsets[0];
+        int nrows_full = P.manager->halo_offsets[P.manager->neighbors.size()];
+        int nz_full = R.row_offsets[nrows_full];
+        int nz_owned = R.row_offsets[nrows_owned];
+        R.manager->setViewSizes(nrows_owned, nz_owned, nrows_owned, nz_owned, nrows_full, nz_full, R.get_num_rows(), R.get_num_nz());
+    }
+
     R.set_initialized(1);
     this->Profile.toc("computeR");
 }


### PR DESCRIPTION
It seems that cuSPARSE generic routines capture an issue with the calculation of nnz in the latency hiding, so it was necessary to calculate those values correctly and add some plumbing to fetch the correct values. I had to work around the behaviour in set_initialized (for Matrix and DistributedManager). If you can see a better way of doing this let me know though.

Some issues were reported regarding block sizes, so I added latency hiding in multiply to overcome this.