### PR TITLE
MPI_DIRECT communicator fix

### DIFF
--- a/base/include/distributed/comms_visitors.h
+++ b/base/include/distributed/comms_visitors.h
@@ -896,7 +896,7 @@ struct ExcHalo3AsyncFunctor: ExcHalo1Functor<TConfig, Tb>
     ExcHalo3AsyncFunctor(Tb &b,
                          const Matrix<TConfig> &m,
                          int num_rings,
-                         int offset, 
+                         int offset,
                          cudaStream_t stream):
         ExcHalo1Functor<TConfig, Tb>(b, m, num_rings, offset, stream)
     {

--- a/base/src/amgx_cusparse.cu
+++ b/base/src/amgx_cusparse.cu
@@ -205,12 +205,12 @@ void Cusparse::bsrmv_with_mask_restriction(
     bool latencyHiding = (R.getViewInterior() != R.getViewExterior() && !P.is_matrix_singleGPU() && x.dirtybit != 0);
 
     if (latencyHiding)
-	  {
+    {
         cudaStream_t null_stream = 0;
-		    bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, HALO1, null_stream, P);
+        bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, HALO1, null_stream, P);
         P.manager->add_from_halo_split_gather(y, y.tag);
-		    cudaEventRecord(P.manager->get_comm_event());
-		    bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, OWNED, null_stream, P);
+        cudaEventRecord(P.manager->get_comm_event());
+        bsrmv_internal_with_mask_restriction(alphaConst, R, x, betaConst, y, OWNED, null_stream, P);
 
         if (P.manager->neighbors.size() != 0)
         {

--- a/base/src/distributed/comms_visitors4.cu
+++ b/base/src/distributed/comms_visitors4.cu
@@ -139,7 +139,7 @@ void AddFromHalo1Functor<TConfig, Tb>::operator()(CommsMPIDirect<TConfig> &comm)
                   size * sizeof(typename Tb::value_type),
                   MPI_BYTE,
                   m.manager->neighbors[i],
-                  tag, 
+                  tag,
                   mpi_comm,
                   &b.requests[i]);
         offset += size;
@@ -378,7 +378,7 @@ void SendRecvWait1Functor<TConfig, Tb>::operator()(CommsMPIDirect<TConfig> &comm
 #ifdef AMGX_WITH_MPI
     Tb &b = get_b();
     const Matrix<TConfig> &m = get_m();
-    int neighbors = m.manager->num_neighbors(); 
+    int neighbors = m.manager->num_neighbors();
     int bsize = b.get_block_size();
     cudaStream_t &stream = get_stream();
     int tag = get_tag();


### PR DESCRIPTION
The MPI_DIRECT communicator fails in the case that there are more than 2 rings. This is because the routine ExcHalo3Functor was not implemented.

This patch implements that function and changes the buffer allocations to support this.