### PR TITLE
Wrapping thrust calls to use memory manager

### DIFF
--- a/base/include/cusp/detail/device/conversion_utils.h
+++ b/base/include/cusp/detail/device/conversion_utils.h
@@ -33,6 +33,7 @@
 #include <thrust/unique.h>
 
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust_wrapper.h>
 
 
 namespace cusp
@@ -102,7 +103,7 @@ size_t count_diagonals(const size_t num_rows,
 						    occupied_diagonal_functor<IndexType>(num_rows)), 
 		    values.begin());
 
-    return thrust::reduce(values.begin(), values.end());
+    return thrust_wrapper::reduce(values.begin(), values.end());
 }
 
 template <typename Matrix>
@@ -176,7 +177,7 @@ size_t compute_optimal_entries_per_row(const  Array1d& row_offsets,
     thrust::adjacent_difference( row_offsets.begin()+1, row_offsets.end(), entries_per_row.begin() );
 
     // sort data to bring equal elements together
-    thrust::sort(entries_per_row.begin(), entries_per_row.end());
+    thrust_wrapper::sort(entries_per_row.begin(), entries_per_row.end());
 
     // find the end of each bin of values
     thrust::counting_iterator<IndexType> search_begin(0);

--- a/base/include/cusp/detail/device/spmm/coo.h
+++ b/base/include/cusp/detail/device/spmm/coo.h
@@ -95,10 +95,10 @@ void coo_spmm_helper(size_t workspace_size,
                                   B_gather_locations.begin());
 
     
-    thrust::gather(A_gather_locations.begin(), A_gather_locations.end(),
+    thrust_wrapper::gather(A_gather_locations.begin(), A_gather_locations.end(),
                    A.row_indices.begin(),
                    I.begin());
-    thrust::gather(B_gather_locations.begin(), B_gather_locations.end(),
+    thrust_wrapper::gather(B_gather_locations.begin(), B_gather_locations.end(),
                    B.column_indices.begin(),
                    J.begin());
 
@@ -164,7 +164,7 @@ void spmm_coo(const Matrix1& A,
 
     // for each element A(i,j) compute the number of nonzero elements in B(j,:)
     cusp::array1d<IndexType,MemorySpace> segment_lengths(A.num_entries);
-    thrust::gather(A.column_indices.begin(), A.column_indices.end(),
+    thrust_wrapper::gather(A.column_indices.begin(), A.column_indices.end(),
                    B_row_lengths.begin(),
                    segment_lengths.begin());
     
@@ -231,7 +231,7 @@ void spmm_coo(const Matrix1& A,
     
         // compute worspace requirements for each row
         cusp::array1d<IndexType,MemorySpace> cummulative_row_workspace(A.num_rows);
-        thrust::gather(A_row_offsets.begin() + 1, A_row_offsets.end(),
+        thrust_wrapper::gather(A_row_offsets.begin() + 1, A_row_offsets.end(),
                        output_ptr.begin(),
                        cummulative_row_workspace.begin());
 

--- a/base/include/cusp/detail/format_utils.inl
+++ b/base/include/cusp/detail/format_utils.inl
@@ -27,6 +27,7 @@
 #include <thrust/sequence.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
+#include <thrust_wrapper.h>
 
 namespace cusp
 {
@@ -66,7 +67,8 @@ void offsets_to_indices(const OffsetArray& offsets, IndexArray& indices)
                                 thrust::make_zip_iterator( thrust::make_tuple( offsets.begin(), offsets.begin()+1 ) ),
                                 empty_row_functor<OffsetType>()),
                     	indices.begin());
-    thrust::inclusive_scan(indices.begin(), indices.end(), indices.begin(), thrust::maximum<OffsetType>());
+
+    thrust_wrapper::inclusive_scan(indices.begin(), indices.end(), indices.begin(), thrust::maximum<OffsetType>());
 }
 
 template <typename IndexArray, typename OffsetArray>
@@ -247,14 +249,14 @@ void sort_by_row(Array1& rows, Array2& columns, Array3& values)
     thrust::sequence(permutation.begin(), permutation.end());
   
     // compute permutation that sorts the rows
-    thrust::sort_by_key(rows.begin(), rows.end(), permutation.begin());
+    thrust_wrapper::sort_by_key(rows.begin(), rows.end(), permutation.begin());
 
     // copy columns and values to temporary buffers
     cusp::array1d<IndexType,MemorySpace> temp1(columns);
     cusp::array1d<ValueType,MemorySpace> temp2(values);
         
     // use permutation to reorder the values
-    thrust::gather(permutation.begin(), permutation.end(),
+    thrust_wrapper::gather(permutation.begin(), permutation.end(),
                    thrust::make_zip_iterator(thrust::make_tuple(temp1.begin(),   temp2.begin())),
                    thrust::make_zip_iterator(thrust::make_tuple(columns.begin(), values.begin())));
 }
@@ -276,20 +278,20 @@ void sort_by_row_and_column(Array1& rows, Array2& columns, Array3& values)
     // compute permutation and sort by (I,J)
     {
         cusp::array1d<IndexType,MemorySpace> temp(columns);
-        thrust::stable_sort_by_key(temp.begin(), temp.end(), permutation.begin());
+        thrust_wrapper::stable_sort_by_key(temp.begin(), temp.end(), permutation.begin());
 
         cusp::copy(rows, temp);
-        thrust::gather(permutation.begin(), permutation.end(), temp.begin(), rows.begin());
-        thrust::stable_sort_by_key(rows.begin(), rows.end(), permutation.begin());
+        thrust_wrapper::gather(permutation.begin(), permutation.end(), temp.begin(), rows.begin());
+        thrust_wrapper::stable_sort_by_key(rows.begin(), rows.end(), permutation.begin());
 
         cusp::copy(columns, temp);
-        thrust::gather(permutation.begin(), permutation.end(), temp.begin(), columns.begin());
+        thrust_wrapper::gather(permutation.begin(), permutation.end(), temp.begin(), columns.begin());
     }
 
     // use permutation to reorder the values
     {
         cusp::array1d<ValueType,MemorySpace> temp(values);
-        thrust::gather(permutation.begin(), permutation.end(), temp.begin(), values.begin());
+        thrust_wrapper::gather(permutation.begin(), permutation.end(), temp.begin(), values.begin());
     }
 }
 

--- a/base/include/cusp/detail/memory.inl
+++ b/base/include/cusp/detail/memory.inl
@@ -19,6 +19,8 @@
 #include <thrust/device_allocator.h>
 #include <thrust/iterator/iterator_traits.h>
 
+#include <vector_thrust_allocator.h>
+
 #if THRUST_VERSION >= 100600
 #include <thrust/device_malloc_allocator.h>
 #endif
@@ -53,7 +55,7 @@ namespace detail
           thrust::detail::eval_if<
             thrust::detail::is_convertible<MemorySpace, device_memory>::value,
   
-            thrust::detail::identity_< thrust::device_malloc_allocator<T> >,
+            thrust::detail::identity_< amgx::thrust_amgx_allocator<T> >,
   
             thrust::detail::identity_< MemorySpace >
           >

--- a/base/include/cusp/precond/detail/smooth.inl
+++ b/base/include/cusp/precond/detail/smooth.inl
@@ -26,6 +26,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust_wrapper.h>
 
 namespace cusp
 {
@@ -65,7 +66,7 @@ void smooth_prolongator(const cusp::coo_matrix<IndexType,ValueType,cusp::device_
   // temp <- -lambda * S(i,j) * T(j,k)
   cusp::coo_matrix<IndexType,ValueType,cusp::device_memory> temp(S.num_rows, T.num_cols, S.num_entries + T.num_entries);
   thrust::copy(S.row_indices.begin(), S.row_indices.end(), temp.row_indices.begin());
-  thrust::gather(S.column_indices.begin(), S.column_indices.end(), T.column_indices.begin(), temp.column_indices.begin());
+  thrust_wrapper::gather(S.column_indices.begin(), S.column_indices.end(), T.column_indices.begin(), temp.column_indices.begin());
   thrust::transform(S.values.begin(), S.values.end(),
                     thrust::make_permutation_iterator(T.values.begin(), S.column_indices.begin()),
                     temp.values.begin(),

--- a/base/include/thrust_wrapper.h
+++ b/base/include/thrust_wrapper.h
@@ -1,0 +1,137 @@
+#pragma once 
+
+#include <thrust/scan.h>
+#include <thrust/reduce.h>
+#include <thrust/sort.h>
+#include <thrust/gather.h>
+#include <thrust/count.h>
+#include <thrust/transform.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <vector_thrust_allocator.h>
+#include <thrust/transform_reduce.h>
+
+namespace thrust_wrapper
+{
+  template<typename InputIterator, typename OutputIterator>
+    inline void exclusive_scan(InputIterator first, InputIterator last, OutputIterator result)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      thrust::exclusive_scan(thrust::cuda::par(alloc), first, last, result);
+    }
+
+  template<typename InputIterator, typename OutputIterator, typename T>
+    inline void exclusive_scan(InputIterator first, InputIterator last, OutputIterator result, T init)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      thrust::exclusive_scan(thrust::cuda::par(alloc), first, last, result, init);
+    }
+
+  template<typename InputIterator, typename OutputIterator>
+    inline void inclusive_scan(InputIterator first, InputIterator last, OutputIterator result)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      thrust::inclusive_scan(thrust::cuda::par(alloc), first, last, result);
+    }
+
+  template<typename InputIterator, typename OutputIterator, typename AssociativeOperator>
+    inline void inclusive_scan(InputIterator first, InputIterator last, OutputIterator result, AssociativeOperator binary_op)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      thrust::inclusive_scan(thrust::cuda::par(alloc), first, last, result, binary_op);
+    }
+
+  template<typename RandomAccessIterator>
+    inline void sort(RandomAccessIterator first, RandomAccessIterator last)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<RandomAccessIterator>::value_type> alloc;
+      thrust::sort(thrust::cuda::par(alloc), first, last);
+    }
+
+  template<typename RandomAccessIterator1, typename RandomAccessIterator2>
+    inline void sort_by_key(RandomAccessIterator1 keys_first, RandomAccessIterator1 keys_last, RandomAccessIterator2 values_first)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<RandomAccessIterator1>::value_type> alloc;
+      thrust::sort_by_key(thrust::cuda::par(alloc), keys_first, keys_last, values_first);
+    }
+
+  template<typename RandomAccessIterator1, typename RandomAccessIterator2>
+    inline void stable_sort_by_key(RandomAccessIterator1 keys_first, RandomAccessIterator1 keys_last, RandomAccessIterator2 values_first)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<RandomAccessIterator1>::value_type> alloc;
+      thrust::stable_sort_by_key(thrust::cuda::par(alloc), keys_first, keys_last, values_first);
+    }
+
+  template<typename InputIterator>
+    inline typename thrust::iterator_traits<InputIterator>::value_type reduce(InputIterator first, InputIterator last)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::reduce(thrust::cuda::par(alloc), first, last);
+    }
+
+  template<typename InputIterator, typename T, typename BinaryFunction>
+    inline T reduce(InputIterator first, InputIterator last, T init, BinaryFunction binary_op)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::reduce(thrust::cuda::par(alloc), first, last, init, binary_op);
+    }
+
+  template<typename InputIterator, typename OutputIterator, typename UnaryFunction>
+    inline OutputIterator transform(InputIterator first, InputIterator last, OutputIterator result, UnaryFunction op)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::transform(thrust::cuda::par(alloc), first, last, result, op);
+    }
+
+  template<typename InputIterator, typename OutputIterator, typename RandomAccessIterator>
+    inline OutputIterator gather(InputIterator map_first, InputIterator map_last, RandomAccessIterator input_first, OutputIterator result)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::gather(thrust::cuda::par(alloc), map_first, map_last, input_first, result);
+    }
+
+  template<typename InputIterator , typename UnaryFunction , typename OutputType , typename BinaryFunction >
+    inline OutputType transform_reduce(InputIterator first, InputIterator last, UnaryFunction unary_op, OutputType init, BinaryFunction binary_op)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::transform_reduce(thrust::cuda::par(alloc), first, last, unary_op, init, binary_op);
+    }
+
+  template<typename InputIterator, typename UnaryFunction>
+    inline InputIterator for_each(InputIterator first, InputIterator last, UnaryFunction f)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::for_each(thrust::cuda::par(alloc), first, last, f);
+    }
+
+  template<typename InputIterator , typename OutputIterator >
+    inline OutputIterator copy(InputIterator first, InputIterator last, OutputIterator result, cudaStream_t stream = 0, bool sync_default = false)
+    {
+      if(sync_default) {
+        cudaStreamSynchronize(0);
+      }
+      OutputIterator res = thrust::copy(thrust::cuda::par.on(stream), first, last, result);
+      cudaStreamSynchronize(stream);
+      return res;
+    }
+
+  template<typename InputIterator, typename EqualityComparable>
+    inline typename thrust::iterator_traits<InputIterator>::difference_type count(InputIterator first, InputIterator last, const EqualityComparable& value) 
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::count(thrust::cuda::par(alloc), first, last, value);
+    }
+
+  template<typename InputIterator, typename Predicate >
+    inline typename thrust::iterator_traits<InputIterator>::difference_type count_if(InputIterator first, InputIterator last, Predicate pred)
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::count_if(thrust::cuda::par(alloc), first, last, pred);
+    }
+
+  template<typename InputIterator , typename OutputIterator >
+    inline OutputIterator adjacent_difference(InputIterator first, InputIterator last, OutputIterator result)	
+    {
+      amgx::thrust_amgx_allocator<typename thrust::iterator_traits<InputIterator>::value_type> alloc;
+      return thrust::adjacent_difference(thrust::cuda::par(alloc), first, last, result);
+    }
+}

--- a/base/include/vector_thrust_allocator.h
+++ b/base/include/vector_thrust_allocator.h
@@ -32,6 +32,7 @@
 #include <thrust/device_reference.h>
 #include <thrust/device_malloc.h>
 #include <thrust/device_free.h>
+#include <thrust/device_vector.h>
 #include <limits>
 #include <stdexcept>
 

--- a/base/src/amgx_c.cu
+++ b/base/src/amgx_c.cu
@@ -53,6 +53,7 @@
 #include <solvers/solver.h>
 #include <matrix.h>
 #include <vector.h>
+#include <thrust_wrapper.h>
 
 #include "amgx_types/util.h"
 #include "amgx_types/rand.h"
@@ -218,7 +219,7 @@ int create_part_offsets(int &root, int &rank, MPI_Comm &mpicm, Matrix<TConfig> *
         }
 
         //perform a prefix sum
-        thrust::inclusive_scan(nv_mtx->manager->part_offsets_h.begin(), nv_mtx->manager->part_offsets_h.end(), nv_mtx->manager->part_offsets_h.begin());
+        thrust_wrapper::inclusive_scan(nv_mtx->manager->part_offsets_h.begin(), nv_mtx->manager->part_offsets_h.end(), nv_mtx->manager->part_offsets_h.begin());
         //create the corresponding array on device (this is important)
         nv_mtx->manager->part_offsets.resize(nranks + 1);
         thrust::copy(nv_mtx->manager->part_offsets_h.begin(), nv_mtx->manager->part_offsets_h.end(), nv_mtx->manager->part_offsets.begin());

--- a/base/src/csr_multiply_sm20.cu
+++ b/base/src/csr_multiply_sm20.cu
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <iostream>
 #include <thrust/scan.h>
+#include <thrust_wrapper.h>
 #include <csr_multiply.h>
 #include <csr_multiply_sm20.h>
 
@@ -1775,7 +1776,7 @@ void CSR_Multiply_Sm20<TemplateConfig<AMGX_device, V, M, I> >::compute_offsets( 
 {
     thrust::device_ptr<int> offsets_begin(C.row_offsets.raw());
     thrust::device_ptr<int> offsets_end  (C.row_offsets.raw() + C.get_num_rows() + 1);
-    thrust::exclusive_scan( offsets_begin, offsets_end, offsets_begin );
+    thrust_wrapper::exclusive_scan( C.row_offsets.begin(), C.row_offsets.begin() + C.get_num_rows() + 1, C.row_offsets.begin() );
     cudaCheckError();
 }
 

--- a/base/src/csr_multiply_sm35.cu
+++ b/base/src/csr_multiply_sm35.cu
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <iostream>
 #include <thrust/scan.h>
+#include <thrust_wrapper.h>
 #include <util.h>
 #include <csr_multiply.h>
 #include <csr_multiply_sm35.h>
@@ -1712,7 +1713,7 @@ void CSR_Multiply_Sm35<TemplateConfig<AMGX_device, V, M, I> >::compute_offsets( 
 {
     thrust::device_ptr<int> offsets_begin(C.row_offsets.raw());
     thrust::device_ptr<int> offsets_end  (C.row_offsets.raw() + C.get_num_rows() + 1);
-    thrust::exclusive_scan( offsets_begin, offsets_end, offsets_begin );
+    thrust_wrapper::exclusive_scan( offsets_begin, offsets_end, offsets_begin );
     cudaCheckError();
 }
 

--- a/base/src/distributed/distributed_arranger.cu
+++ b/base/src/distributed/distributed_arranger.cu
@@ -41,6 +41,7 @@
 #include <sm_utils.inl>
 #include <csr_multiply.h>
 #include <algorithm>
+#include <thrust_wrapper.h>
 
 #include <amgx_types/util.h>
 
@@ -1147,7 +1148,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     thrust::copy(halo_offsets.begin(), halo_offsets.end(), halo_offsets_d.begin());
     int last_halo = halo_nodes[halo_nodes.size() - 1];
     //create renumbering of halo indices (contiguously neighbor - by - neighbor, indexing starting with the number of owned rows
-    thrust::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin(), size);
+    thrust_wrapper::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin(), size);
     cudaCheckError();
     A.manager->local_to_global_map.resize(halo_nodes[halo_nodes.size() - 1] - size + last_halo);
     renumber_col_indices<16> <<< num_blocks, 128>>>(A.row_offsets.raw(), A.col_indices.raw(), halo_ranges.raw(), halo_nodes.raw(), halo_offsets_d.raw(), base_index, index_range, num_neighbors, size, A.manager->local_to_global_map.raw());
@@ -1186,7 +1187,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     thrust::copy(halo_offsets.begin(), halo_offsets.end(), halo_offsets_d.begin());
     int last_halo = (halo_nodes.size() > 0) ? halo_nodes[halo_nodes.size() - 1] : 0;
     //create renumbering of halo indices (contiguously neighbor - by - neighbor, indexing starting with the number of owned rows
-    thrust::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin(), size);
+    thrust_wrapper::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin(), size);
     cudaCheckError();
 
     if (halo_nodes.size() > 0)
@@ -1643,11 +1644,11 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
 
     if (boundary_flags.size() > 1)
     {
-        thrust::exclusive_scan(boundary_flags.begin(), boundary_flags.end(), boundary_flags.begin());
+        thrust_wrapper::exclusive_scan(boundary_flags.begin(), boundary_flags.end(), boundary_flags.begin());
         cudaCheckError();
     }
 
-    thrust::exclusive_scan(interior_flags.begin(), interior_flags.end(), interior_flags.begin());
+    thrust_wrapper::exclusive_scan(interior_flags.begin(), interior_flags.end(), interior_flags.begin());
     cudaCheckError();
     int num_interior_rows = interior_flags[size];
     int num_boundary_rows = boundary_flags[size];
@@ -1715,7 +1716,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         // compute halo indices map [<neighbor inner node>] = 0-based halo number
         int size = halo_offsets[i + 1] - halo_offsets[i];
         thrust::replace_copy_if(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin(), pred, 1);
-        thrust::exclusive_scan(halo_indices.begin(), halo_indices.begin() + size + 1, halo_indices.begin());
+        thrust_wrapper::exclusive_scan(halo_indices.begin(), halo_indices.begin() + size + 1, halo_indices.begin());
         cudaCheckError();
         int num_halo = halo_indices[size];
         A.manager->L2H_maps[i].resize(num_halo);
@@ -1904,7 +1905,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     for (int i = 0; i < num_neighbors; i++)
     {
         int last = halo_nodes[halo_offsets[i + 1] - 1];
-        thrust::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
+        thrust_wrapper::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
         int num_halo = halo_indices[halo_offsets[i + 1] - halo_offsets[i] - 1] + last;
         //A.manager.B2L_maps[i].resize(num_halo);
         boundary_lists[i].resize(num_halo);
@@ -1957,7 +1958,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     for (int i = 0; i < num_neighbors; i++)
     {
         int last = halo_nodes[halo_offsets[i + 1] - 1];
-        thrust::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
+        thrust_wrapper::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
         int num_halo = halo_indices[halo_offsets[i + 1] - halo_offsets[i] - 1] + last;
         //A.manager.B2L_maps[i].resize(num_halo);
         boundary_lists[i].resize(num_halo);
@@ -2027,7 +2028,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     {
         // compute halo indices map [<neighbor inner node>] = 0-based halo number
         last[i] = halo_nodes[halo_offsets[i + 1] - 1];
-        thrust::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
+        thrust_wrapper::exclusive_scan(halo_nodes.begin() + halo_offsets[i], halo_nodes.begin() + halo_offsets[i + 1], halo_indices.begin());
         num_halo[i] = halo_indices[halo_offsets[i + 1] - halo_offsets[i] - 1] + last[i];
         // renumber my columns for this particular neighbor
         calc_new_halo_mapping<16> <<< num_blocks, 128>>>(A.row_offsets.raw(), A.col_indices.raw(), A.manager->halo_ranges.raw() + (int64_t) (2 * i), 1, size, A.manager->local_to_global_map.raw(), new_local_to_global_map.raw(), halo_indices.raw(), halo_base, A.manager->global_id());
@@ -2155,7 +2156,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         if (neighbor_offsets_h[i + 1] != neighbor_offsets_h[i])
         {
             last_node = neighbor_nodes[neighbor_offsets_h[i + 1] - 1];
-            thrust::exclusive_scan(neighbor_nodes.begin() + neighbor_offsets_h[i], neighbor_nodes.begin() + neighbor_offsets_h[i + 1], neighbor_nodes.begin() + neighbor_offsets_h[i]);
+            thrust_wrapper::exclusive_scan(neighbor_nodes.begin() + neighbor_offsets_h[i], neighbor_nodes.begin() + neighbor_offsets_h[i + 1], neighbor_nodes.begin() + neighbor_offsets_h[i]);
             num_halo = neighbor_nodes[neighbor_offsets_h[i + 1] - 1] + last_node;
         }
         else
@@ -2276,7 +2277,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
              halo_rings: [0 0 1 1]
              */
             //Count, index and append them to B2L_maps and update B2L_rings
-            thrust::inclusive_scan(halo_rings.begin(), halo_rings.begin() + size + 1, halo_rings.begin());
+            thrust_wrapper::inclusive_scan(halo_rings.begin(), halo_rings.begin() + size + 1, halo_rings.begin());
             B2L_rings[i][ring + 1] = B2L_rings[i][ring] + halo_rings[size];
             B2L_maps[i].resize(B2L_rings[i][ring + 1]);
 
@@ -2340,7 +2341,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             num_blocks = min(4096, (size + 127) / 128);
             find_next_ring <<< num_blocks, 128>>>(A.manager->B2L_maps[i].raw() + A.manager->B2L_rings[i][ring - 1], A.row_offsets.raw(), A.col_indices.raw(), size, 0/*base_index*/, /*index_range*/size, halo_rings.raw());
             remove_previous_rings <<< num_blocks, 128>>>(A.manager->B2L_maps[i].raw(), halo_rings.raw(), A.manager->B2L_rings[i][ring]);
-            thrust::inclusive_scan(halo_rings.begin(), halo_rings.begin() + size + 1, halo_rings.begin());
+            thrust_wrapper::inclusive_scan(halo_rings.begin(), halo_rings.begin() + size + 1, halo_rings.begin());
             A.manager->B2L_rings[i][ring + 1] = A.manager->B2L_rings[i][ring] + halo_rings[size];
             A.manager->B2L_maps[i].resize(A.manager->B2L_rings[i][ring + 1]);
 
@@ -2457,7 +2458,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         matrix_halo_sizes.resize(size + 1);
         int num_blocks = min(4096, (size + 127) / 128);
         write_matrix_rowsize <<< num_blocks, 128>>>(B2L_maps[i].raw(), A.row_offsets.raw(), size, matrix_halo_sizes.raw());
-        thrust::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
+        thrust_wrapper::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
         int nnz_count =  matrix_halo_sizes[size];
         //
         // Resize export halo matrix, and copy over the rows
@@ -2560,7 +2561,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     }
 
     // Step 3: Write the 1-ring global nodes for each neighbor
-    thrust::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin());
+    thrust_wrapper::exclusive_scan(halo_nodes.begin(), halo_nodes.end(), halo_nodes.begin());
     cudaCheckError();
     std::vector<IVector> bdy_lists;
     bdy_lists.resize(num_neighbors);
@@ -2673,7 +2674,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     }
 
     IVector row_sizes(row_offsets.size() - 1);
-    thrust::adjacent_difference(row_offsets.begin() + 1, row_offsets.end(), row_sizes.begin());
+    thrust_wrapper::adjacent_difference(row_offsets.begin() + 1, row_offsets.end(), row_sizes.begin());
     cudaCheckError();
     IVector B2L_maps_offsets(max_B2L_maps_size + 1);
 
@@ -2684,9 +2685,9 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         if (A_b2l_map_size > 0)
         {
             // For each node in the B2L_map for that neighbor, write the row size in B2L_maps_offsets
-            thrust::gather(A.manager->B2L_maps[i].begin(), A.manager->B2L_maps[i].begin() + A_b2l_map_size, row_sizes.begin(), B2L_maps_offsets.begin());
+            thrust_wrapper::gather(A.manager->B2L_maps[i].begin(), A.manager->B2L_maps[i].begin() + A_b2l_map_size, row_sizes.begin(), B2L_maps_offsets.begin());
             // Do exclusive scan, to go from row length to row offsets
-            thrust::exclusive_scan(B2L_maps_offsets.begin(), B2L_maps_offsets.begin() + A_b2l_map_size + 1, B2L_maps_offsets.begin());
+            thrust_wrapper::exclusive_scan(B2L_maps_offsets.begin(), B2L_maps_offsets.begin() + A_b2l_map_size + 1, B2L_maps_offsets.begin());
             B.manager->B2L_maps[i].resize(B2L_maps_offsets[A_b2l_map_size]);
             const int cta_size = 128;
             const int nWarps = cta_size / 32;
@@ -2815,7 +2816,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
     cudaCheckError();
     A.row_offsets[A.get_num_rows()] = cur_offset;
     int num_cols = -1;
-    num_cols = thrust::reduce(A.col_indices.begin(), A.col_indices.end(), num_cols, thrust::maximum<int>()) + 1;
+    num_cols = thrust_wrapper::reduce(A.col_indices.begin(), A.col_indices.end(), num_cols, thrust::maximum<int>()) + 1;
     cudaCheckError();
     A.set_num_cols(num_cols);
 }
@@ -2913,7 +2914,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             //matrix_halo_sizes.resize(size+1);
             int num_blocks = min(4096, (size + 127) / 128);
             write_matrix_rowsize <<< num_blocks, 128>>>(A.manager->B2L_maps[i].raw(), P.row_offsets.raw(), size, matrix_halo_sizes.raw());
-            thrust::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
+            thrust_wrapper::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
             int nnz_count =  matrix_halo_sizes[size];
             // Resize export halo matrix, and copy over the rows
             halo_rows_P_row_offsets[i].resize(size + 1);
@@ -3000,7 +3001,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             //matrix_halo_sizes.resize(size+1);
             int num_blocks = min(4096, (size + 127) / 128);
             write_matrix_rowsize <<< num_blocks, 128>>>(tmp_B2L_maps[i].raw(), RAP.row_offsets.raw(), size, matrix_halo_sizes.raw());
-            thrust::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
+            thrust_wrapper::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
             int nnz_count =  matrix_halo_sizes[size];
             // Resize export halo matrix, and copy over the rows
             halo_rows_RAP_row_offsets[i].resize(tmp_B2L_maps[i].size() + 1);
@@ -3091,7 +3092,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         matrix_halo_sizes.resize(size + 1);
         int num_blocks = min(4096, (size + 127) / 128);
         write_matrix_rowsize <<< num_blocks, 128>>>(A.manager->B2L_maps[i].raw(), A.row_offsets.raw(), size, matrix_halo_sizes.raw());
-        thrust::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
+        thrust_wrapper::exclusive_scan(matrix_halo_sizes.begin(), matrix_halo_sizes.begin() + size + 1, matrix_halo_sizes.begin());
         cudaCheckError();
         int nnz_count =  matrix_halo_sizes[size];
         //
@@ -3134,7 +3135,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         {
             int num_blocks = min(4096, (size + 127) / 128);
             write_matrix_rowsize <<< num_blocks, 128>>>(A.manager->B2L_maps[i].raw(), A.row_offsets.raw(), size, halo_rows_row_offsets[i].raw());
-            thrust::exclusive_scan(halo_rows_row_offsets[i].begin(), halo_rows_row_offsets[i].begin() + size + 1, halo_rows_row_offsets[i].begin());
+            thrust_wrapper::exclusive_scan(halo_rows_row_offsets[i].begin(), halo_rows_row_offsets[i].begin() + size + 1, halo_rows_row_offsets[i].begin());
             // compute global indices
             int nnz_count = halo_rows_row_offsets[i][size];
             halo_rows_col_indices[i].resize(nnz_count);
@@ -3190,7 +3191,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             //send over B2L and L2H maps corresponding to current neighbor, so that it will be able to make sense of indices (local to this partition)
             thrust::copy(B2L_maps[i].begin(), B2L_maps[i].end(), halo_btl[i].B2L_maps[0].begin());
             thrust::copy(halo_lists[i]->begin(), halo_lists[i]->end(), halo_btl[i].L2H_maps[0].begin());
-            int max_index = thrust::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
+            int max_index = thrust_wrapper::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
             max_index = max_index > A.get_num_rows() ? max_index : A.get_num_rows();
             halo_btl[i].set_index_range(max_index);
             thrust::copy(B2L_rings[i].begin(), B2L_rings[i].end(), halo_btl[i].B2L_rings[0].begin());
@@ -3221,7 +3222,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             //Even though in this case matrices are not being sent over, we create the same data structures, so they can be handled the same way
             thrust::copy(B2L_maps[i].begin(), B2L_maps[i].end(), halo_btl[i].L2H_maps[0].begin());
             thrust::copy(halo_lists[i]->begin(), halo_lists[i]->end(), halo_btl[i].B2L_maps[0].begin());
-            int max_index = thrust::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
+            int max_index = thrust_wrapper::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
             max_index = max_index > A.get_num_rows() ? max_index : A.get_num_rows();
             halo_btl[i].set_index_range(max_index);
             halo_btl[i].B2L_rings[0][0] = 0;
@@ -3265,7 +3266,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             halo_btl[i].L2H_maps[0].resize(halo_lists[i]->size());
             thrust::copy(A.manager->B2L_maps[i].begin(), A.manager->B2L_maps[i].end(), halo_btl[i].B2L_maps[0].begin());
             thrust::copy(halo_lists[i]->begin(), halo_lists[i]->end(), halo_btl[i].L2H_maps[0].begin());
-            int max_index = thrust::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
+            int max_index = thrust_wrapper::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
             max_index = max_index > A.get_num_rows() ? max_index : A.get_num_rows();
             halo_btl[i].set_index_range(max_index);
             thrust::copy(A.manager->B2L_rings[i].begin(), A.manager->B2L_rings[i].end(), halo_btl[i].B2L_rings[0].begin());
@@ -3288,7 +3289,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             halo_btl[i].L2H_maps[0].resize(A.manager->B2L_rings[i][rings]);
             thrust::copy(A.manager->B2L_maps[i].begin(), A.manager->B2L_maps[i].end(), halo_btl[i].L2H_maps[0].begin());
             thrust::copy(halo_lists[i]->begin(), halo_lists[i]->end(), halo_btl[i].B2L_maps[0].begin());
-            int max_index = thrust::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
+            int max_index = thrust_wrapper::reduce(halo_lists[i]->begin(), halo_lists[i]->end(), (int)0, thrust::maximum<int>()) + 1;
             max_index = max_index > A.get_num_rows() ? max_index : A.get_num_rows();
             halo_btl[i].set_index_range(max_index);
             halo_btl[i].B2L_rings[0][0] = 0;
@@ -3323,7 +3324,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         thrust::copy(A.manager->L2H_maps[i].begin(), A.manager->L2H_maps[i].end(), halo_btl[i].L2H_maps[0].begin());
         thrust::copy(A.manager->B2L_rings[i].begin(), A.manager->B2L_rings[i].end(), halo_btl[i].B2L_rings[0].begin());
         // compute index range
-        int max_index = thrust::reduce(A.manager->L2H_maps[i].begin(), A.manager->L2H_maps[i].end(), (int)0, thrust::maximum<int>()) + 1;
+        int max_index = thrust_wrapper::reduce(A.manager->L2H_maps[i].begin(), A.manager->L2H_maps[i].end(), (int)0, thrust::maximum<int>()) + 1;
         max_index = max_index > A.get_num_rows() ? max_index : A.get_num_rows();
         halo_btl[i].set_index_range(max_index);
     }

--- a/base/src/distributed/distributed_io.cu
+++ b/base/src/distributed/distributed_io.cu
@@ -27,6 +27,7 @@
 
 #include <distributed/distributed_io.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust_wrapper.h>
 #include <amgx_types/util.h>
 
 namespace amgx

--- a/base/src/distributed/distributed_manager.cu
+++ b/base/src/distributed/distributed_manager.cu
@@ -35,6 +35,7 @@
 #include <thrust/unique.h>
 #include <thrust/binary_search.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust_wrapper.h>
 #include <basic_types.h>
 #include <error.h>
 #include <util.h>
@@ -1015,7 +1016,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     const int cta_size = 128;
     const int grid_size = std::min( 4096, (num_rows + cta_size - 1) / cta_size );
     poisson7pt_count_row_len <<< grid_size, cta_size>>>(this->A->row_offsets.raw(), nx, ny, nz, p, q, r, P, Q, R, num_rows);
-    thrust::exclusive_scan(this->A->row_offsets.begin(), this->A->row_offsets.end(), this->A->row_offsets.begin());
+    thrust_wrapper::exclusive_scan(this->A->row_offsets.begin(), this->A->row_offsets.end(), this->A->row_offsets.begin());
     cudaCheckError();
     // Now set nonzeros columns and values
     // TODO: vectorize this
@@ -1462,7 +1463,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     cudaCheckError();
     global_col_indices.dirtybit = 1;
     this->exchange_halo(global_col_indices, global_col_indices.tag);
-    thrust::copy(global_col_indices.begin() + num_owned_rows, global_col_indices.begin() + size_one_ring, this->local_to_global_map.begin());
+    thrust_wrapper::copy(global_col_indices.begin() + num_owned_rows, global_col_indices.begin() + size_one_ring, this->local_to_global_map.begin(), this->get_int_stream(), true);
     cudaCheckError();
 }
 
@@ -1514,7 +1515,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
         cudaCheckError();
     }
 
-    thrust::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + num_owned_coarse_pts + 1, new_row_offsets.begin());
+    thrust_wrapper::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + num_owned_coarse_pts + 1, new_row_offsets.begin());
     cudaCheckError();
     // Copy the row_offsets for halo rows
     thrust::copy(R.row_offsets.begin() + num_owned_coarse_pts, R.row_offsets.end(), new_row_offsets.begin() + num_owned_coarse_pts);
@@ -1546,7 +1547,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
         cudaCheckError();
         global_col_indices.dirtybit = 1;
         P.manager->exchange_halo(global_col_indices, global_col_indices.tag);
-        thrust::copy(global_col_indices.begin() + num_owned_coarse_pts, global_col_indices.begin() + size_one_ring, P.manager->local_to_global_map.begin());
+        thrust_wrapper::copy(global_col_indices.begin() + num_owned_coarse_pts, global_col_indices.begin() + size_one_ring, P.manager->local_to_global_map.begin(), this->get_int_stream(), true);
         cudaCheckError();
     }
 
@@ -2333,7 +2334,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 
     if (this->L2H_maps.size())
     {
-        size = thrust::reduce(this->A->col_indices.begin(), this->A->col_indices.end(), int(0), thrust::maximum<int>()) + 1; //Sufficient to do reduction on lth maps
+        size = thrust_wrapper::reduce(this->A->col_indices.begin(), this->A->col_indices.end(), int(0), thrust::maximum<int>()) + 1; //Sufficient to do reduction on lth maps
         cudaCheckError();
     }
     else
@@ -2375,7 +2376,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     }
 
     //gets the renumbering of interior nodes
-    thrust::exclusive_scan(flagArray.begin(), flagArray.begin() + size + 1, renumbering.begin());
+    thrust_wrapper::exclusive_scan(flagArray.begin(), flagArray.begin() + size + 1, renumbering.begin());
     cudaCheckError();
     /*
      EXAMPLE
@@ -2427,7 +2428,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
                     boundary_renum_flags.raw(), size, global_size /*,rank*/);
 
         //calculate the local renumbering (within this boundary region) of these nodes
-        thrust::exclusive_scan(boundary_renum_flags.begin(), boundary_renum_flags.begin() + max_size, boundary_renum.begin());
+        thrust_wrapper::exclusive_scan(boundary_renum_flags.begin(), boundary_renum_flags.begin() + max_size, boundary_renum.begin());
 
         //apply renumbering to the big numbering table
         if (size > 0)
@@ -2476,7 +2477,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
                         boundary_renum_flags.raw(), size, global_size /*,rank*/);
 
             //calculate the local renumbering (within this boundary region) of these nodes
-            thrust::exclusive_scan(boundary_renum_flags.begin(), boundary_renum_flags.begin() + max_size, boundary_renum.begin());
+            thrust_wrapper::exclusive_scan(boundary_renum_flags.begin(), boundary_renum_flags.begin() + max_size, boundary_renum.begin());
 
             //apply renumbering to the big numbering table
             if (size > 0)
@@ -2590,7 +2591,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
                  this->A->col_indices.begin());
     cudaCheckError();
     //row_offsets array created by exclusive scan of row sizes
-    thrust::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + size + 1, new_row_offsets.begin());
+    thrust_wrapper::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + size + 1, new_row_offsets.begin());
     cudaCheckError();
 //
 // Step 7 - consolidate column indices and values
@@ -2954,7 +2955,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 
     cudaCheckError();
     //row_offsets array created by exclusive scan of row sizes
-    thrust::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + size + this->num_halo_rows() + 1, new_row_offsets.begin());
+    thrust_wrapper::exclusive_scan(new_row_offsets.begin(), new_row_offsets.begin() + size + this->num_halo_rows() + 1, new_row_offsets.begin());
     cudaCheckError();
     /*
      EXAMPLE
@@ -4458,7 +4459,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
         cudaEventCreate(&event);
         // Populate the halo rows with diagonal, increase the length of the halo rows
         thrust::fill(this->A->row_offsets.begin() + halo_offsets[0], this->A->row_offsets.begin() + halo_offsets[root_num_cons_neighbors], 1);
-        thrust::exclusive_scan(this->A->row_offsets.begin(), this->A->row_offsets.end(), this->A->row_offsets.begin());
+        thrust_wrapper::exclusive_scan(this->A->row_offsets.begin(), this->A->row_offsets.end(), this->A->row_offsets.begin());
         cudaEventRecord(event);
         cudaEventSynchronize(event);
         cudaCheckError();

--- a/base/src/matrix.cu
+++ b/base/src/matrix.cu
@@ -34,6 +34,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
 #include <thrust/gather.h>
+#include <vector_thrust_allocator.h>
 #include <cusp/detail/format_utils.h>
 #include <permute.h>
 #include <multiply.h>

--- a/base/src/transpose.cu
+++ b/base/src/transpose.cu
@@ -40,6 +40,7 @@
 #endif
 
 #include <thrust/transform.h>
+#include <thrust_wrapper.h>
 
 #include "amgx_types/util.h"
 
@@ -87,7 +88,7 @@ void transpose(const Matrix &A, Matrix &B)
 
         if (types::util<ValueTypeA>::is_complex)
         {
-            thrust::transform(B.values.begin(), B.values.end(), B.values.begin(), conjugate());
+            thrust_wrapper::transform(B.values.begin(), B.values.end(), B.values.begin(), conjugate());
         }
 
         B.set_initialized(1);

--- a/base/src/truncate.cu
+++ b/base/src/truncate.cu
@@ -30,6 +30,7 @@
 #include <basic_types.h>
 #include <util.h>
 #include <algorithm>
+#include <thrust_wrapper.h>
 
 #include "amgx_types/util.h"
 
@@ -710,7 +711,8 @@ void Truncate<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::tr
     // initial resize (so we can scan into the row_offsets array)
     A_trunc.resize(A.get_num_rows(), A.get_num_cols(), 0);
     cudaCheckError();
-    thrust::exclusive_scan(row_counts.begin(), row_counts.end(), A_trunc.row_offsets.begin());
+
+    thrust_wrapper::exclusive_scan(row_counts.begin(), row_counts.end(), A_trunc.row_offsets.begin());
     cudaCheckError();
     
     const int nnz = A_trunc.row_offsets[A.get_num_rows() - 1] + row_counts[A.get_num_rows() - 1];
@@ -837,7 +839,7 @@ void Truncate<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::tr
     // initial definition
     Matrix_d A_trunc(A.get_num_rows(), A.get_num_cols(), 0, CSR); // add CSR prop
     // exclusive scan to get new row structure
-    thrust::exclusive_scan(row_lengths.begin(), row_lengths.end(), A_trunc.row_offsets.begin());
+    thrust_wrapper::exclusive_scan(row_lengths.begin(), row_lengths.end(), A_trunc.row_offsets.begin());
     int nnz = A_trunc.row_offsets[A.get_num_rows() - 1] + row_lengths[A.get_num_rows() - 1];
     A_trunc.row_offsets[A.get_num_rows()] = nnz;
     // set final size of truncated matrix

--- a/core/include/matrix_coloring/bfs.h
+++ b/core/include/matrix_coloring/bfs.h
@@ -30,6 +30,7 @@
 #include <thrust/remove.h>
 #include <thrust/unique.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust_wrapper.h>
 #include <strided_reduction.h>
 #include <vector_thrust_allocator.h>
 
@@ -217,7 +218,7 @@ void bfs(const int start, const int num_rows, const int num_nonzero, const int *
         task_queue_n = task_queue_out_tail[0];
         cudaCheckError();
         //contract duplicates using thrust
-        thrust::sort(task_queue_out.begin(), task_queue_out.begin() + task_queue_n);
+        thrust_wrapper::sort(task_queue_out.begin(), task_queue_out.begin() + task_queue_n);
         cudaCheckError();
         task_queue_n = thrust::unique(task_queue_out.begin(), task_queue_out.begin() + task_queue_n) - task_queue_out.begin();
         cudaCheckError();

--- a/core/src/aggregation/coarseAgenerators/hybrid_coarse_A_generator.cu
+++ b/core/src/aggregation/coarseAgenerators/hybrid_coarse_A_generator.cu
@@ -371,13 +371,13 @@ void HybridCoarseAGenerator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
         cudaCheckError();
         temp = I;
         //I = temp;
-        thrust::gather(permutation.begin(), permutation.end(), temp.begin(), I.begin());
+        thrust_wrapper::gather(permutation.begin(), permutation.end(), temp.begin(), I.begin());
         cudaCheckError();
         thrust::stable_sort_by_key(I.begin(), I.end(), permutation.begin());
         cudaCheckError();
         temp = J;
         //J = temp;
-        thrust::gather(permutation.begin(), permutation.end(), temp.begin(), J.begin());
+        thrust_wrapper::gather(permutation.begin(), permutation.end(), temp.begin(), J.begin());
         cudaCheckError();
     }
     // Remove duplicate tuples

--- a/core/src/aggregation/coarseAgenerators/low_deg_coarse_A_generator.cu
+++ b/core/src/aggregation/coarseAgenerators/low_deg_coarse_A_generator.cu
@@ -30,6 +30,7 @@
 #include <thrust/scan.h>
 #include <thrust/remove.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust_wrapper.h>
 #include <error.h>
 #include <cutil.h>
 #include <util.h>
@@ -1216,7 +1217,7 @@ LowDegCoarseAGenerator<TemplateConfig<AMGX_device, V, M, I> >::computeAOperator(
 
     cudaCheckError();
     // Compute the number of non-zeroes.
-    thrust::exclusive_scan( Ac.row_offsets.begin(), Ac.row_offsets.end(), Ac.row_offsets.begin() );
+    thrust_wrapper::exclusive_scan( Ac.row_offsets.begin(), Ac.row_offsets.end(), Ac.row_offsets.begin() );
     cudaCheckError();
     int nonzero_blocks = Ac.row_offsets[num_aggregates];
 

--- a/core/src/classical/classical_amg_level.cu
+++ b/core/src/classical/classical_amg_level.cu
@@ -39,6 +39,7 @@
 #include <thrust/logical.h>
 #include <thrust/remove.h>
 #include <thrust/adjacent_difference.h>
+#include <thrust_wrapper.h>
 
 #include <thrust/extrema.h> // for minmax_element
 
@@ -342,7 +343,7 @@ void Classical_AMG_Level_Base<T_Config>::createCoarseMatrices()
         RAP.set_initialized(1);
         // update # of columns in P - this is necessary for correct CSR multiply
         P.set_initialized(0);
-        int new_num_cols = thrust::reduce(P.col_indices.begin(), P.col_indices.end(), int(0), thrust::maximum<int>()) + 1;
+        int new_num_cols = thrust_wrapper::reduce(P.col_indices.begin(), P.col_indices.end(), int(0), thrust::maximum<int>()) + 1;
         cudaCheckError();
         P.set_num_cols(new_num_cols);
         P.set_initialized(1);
@@ -558,7 +559,7 @@ void Classical_AMG_Level<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
             cudaCheckError();
             int min_size = *result.first;
             int max_size = *result.second;
-            int sum = thrust::reduce( num_nz.begin() + 1, num_nz.end() );
+            int sum = thrust_wrapper::reduce( num_nz.begin() + 1, num_nz.end() );
             cudaCheckError();
             double avg_size = double(sum) / this->getA().get_num_rows();
             buffer << "SPMM: A: " << std::endl;
@@ -574,7 +575,7 @@ void Classical_AMG_Level<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         cudaCheckError();
         int min_size = *result.first;
         int max_size = *result.second;
-        int sum = thrust::reduce( num_nz.begin() + 1, num_nz.end() );
+        int sum = thrust_wrapper::reduce( num_nz.begin() + 1, num_nz.end() );
         cudaCheckError();
         double avg_size = double(sum) / this->P.get_num_rows();
         buffer << "SPMM: P: " << std::endl;
@@ -588,7 +589,7 @@ void Classical_AMG_Level<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         cudaCheckError();
         min_size = *result.first;
         max_size = *result.second;
-        sum = thrust::reduce( num_nz.begin() + 1, num_nz.end() );
+        sum = thrust_wrapper::reduce( num_nz.begin() + 1, num_nz.end() );
         cudaCheckError();
         avg_size = double(sum) / this->R.get_num_rows();
         buffer << "SPMM: R: " << std::endl;
@@ -813,7 +814,7 @@ void Classical_AMG_Level<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         cudaCheckError();
         */
         //create a pointer map for their location using prefix sum
-        thrust::exclusive_scan(l2g_p.begin(), l2g_p.end(), l2g_p.begin());
+        thrust_wrapper::exclusive_scan(l2g_p.begin(), l2g_p.end(), l2g_p.begin());
         int new_nl2g = l2g_p[nl2g];
 
         //compress the columns using the pointer map

--- a/core/src/classical/interpolators/distance1.cu
+++ b/core/src/classical/interpolators/distance1.cu
@@ -27,6 +27,7 @@
 
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
+#include <thrust_wrapper.h>
 #include <classical/interpolators/distance1.h>
 #include <classical/interpolators/common.h>
 #include <basic_types.h>
@@ -868,9 +869,9 @@ void Distance1_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     // now I have the non-zeros per row for matrix P, count the non-zeros on each row
     // to get total NNZ
     // sum non-zeros per row
-    int NNZidx = thrust::reduce(nonZerosVec.begin(), nonZerosVec.end());
+    int NNZidx = thrust_wrapper::reduce(nonZerosVec.begin(), nonZerosVec.end());
     cudaCheckError();
-    thrust::exclusive_scan(nonZerosVec.begin(), nonZerosVec.end(), nonZerosVec.begin());
+    thrust_wrapper::exclusive_scan(nonZerosVec.begin(), nonZerosVec.end(), nonZerosVec.begin());
     cudaCheckError();
     nonZerosVec[A.get_num_rows()] = NNZidx;
     // generate sets on the device

--- a/core/src/classical/interpolators/distance2.cu
+++ b/core/src/classical/interpolators/distance2.cu
@@ -48,6 +48,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <device_properties.h>
+#include <thrust_wrapper.h>
 
 namespace amgx
 {
@@ -2023,7 +2024,7 @@ void Distance2_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
         cudaCheckError();
     }
     // Compute row offsets.
-    thrust::exclusive_scan( C_hat_start.begin( ), C_hat_start.end( ), C_hat_start.begin( ) );
+    thrust_wrapper::exclusive_scan( C_hat_start.begin( ), C_hat_start.end( ), C_hat_start.begin( ) );
     cudaCheckError();
     // Allocate memory to store columns/values.
     int nVals = C_hat_start[C_hat_start.size() - 1];
@@ -2104,9 +2105,9 @@ void Distance2_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     {
         prep = new DistributedArranger<TConfig_d>;
         int num_owned_fine_pts = A.get_num_rows();
-        int num_owned_coarse_pts = thrust::count_if(cf_map.begin(), cf_map.begin() + num_owned_fine_pts, is_non_neg());
+        int num_owned_coarse_pts = thrust_wrapper::count_if(cf_map.begin(), cf_map.begin() + num_owned_fine_pts, is_non_neg());
         cudaCheckError();
-        int num_halo_coarse_pts = thrust::count_if(cf_map.begin() + num_owned_fine_pts, cf_map.end(), is_non_neg());
+        int num_halo_coarse_pts = thrust_wrapper::count_if(cf_map.begin() + num_owned_fine_pts, cf_map.end(), is_non_neg());
         cudaCheckError();
         coarsePoints = num_owned_coarse_pts + num_halo_coarse_pts;
         // Using the number of owned_coarse_pts (number of rows of Ac), initialize P manager
@@ -2115,7 +2116,7 @@ void Distance2_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     }
     else
     {
-        coarsePoints = (int) thrust::count_if(cf_map.begin(), cf_map.end(), is_non_neg());
+        coarsePoints = (int) thrust_wrapper::count_if(cf_map.begin(), cf_map.end(), is_non_neg());
         cudaCheckError();
     }
 
@@ -2147,10 +2148,10 @@ void Distance2_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     }
 
     // get total with a reduction
-    int nonZeros = thrust::reduce(nonZerosPerRow.begin(), nonZerosPerRow.end());
+    int nonZeros = thrust_wrapper::reduce(nonZerosPerRow.begin(), nonZerosPerRow.end());
     cudaCheckError();
     // get the offsets with an exclusive scan
-    thrust::exclusive_scan(nonZerosPerRow.begin(), nonZerosPerRow.end(), nonZeroOffsets.begin());
+    thrust_wrapper::exclusive_scan(nonZerosPerRow.begin(), nonZerosPerRow.end(), nonZeroOffsets.begin());
     cudaCheckError();
     nonZeroOffsets[A.get_num_rows()] = nonZeros;
     // resize P
@@ -2195,7 +2196,7 @@ void Distance2_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     }
 
     // get the offsets
-    thrust::exclusive_scan( innerSumOffset.begin(), innerSumOffset.end(), innerSumOffset.begin() );
+    thrust_wrapper::exclusive_scan( innerSumOffset.begin(), innerSumOffset.end(), innerSumOffset.begin() );
     cudaCheckError();
     // assign memory & get pointer
     int numInnerSum = innerSumOffset[A.get_num_rows()];

--- a/core/src/classical/selectors/cr.cu
+++ b/core/src/classical/selectors/cr.cu
@@ -39,6 +39,7 @@
 #include <thrust/functional.h>
 #include <thrust/random.h>
 #include <thrust/transform.h>
+#include <thrust_wrapper.h>
 #include <solvers/block_common_solver.h>
 
 
@@ -523,7 +524,7 @@ void CR_Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >
 #endif
     cudaCheckError();
     // get the offsets in Asc with an inclusive scan
-    thrust::inclusive_scan(Asc_nnzPerRow.begin(), Asc_nnzPerRow.end(), Asc_nnzPerRow.begin());
+    thrust_wrapper::inclusive_scan(Asc_nnzPerRow.begin(), Asc_nnzPerRow.end(), Asc_nnzPerRow.begin());
     cudaCheckError();
     // get total num of non-zeros in P
     const int Asc_nnz = Asc_nnzPerRow[AnumRows - 1];

--- a/core/src/classical/selectors/pmis.cu
+++ b/core/src/classical/selectors/pmis.cu
@@ -30,6 +30,7 @@
 #include <cutil.h>
 #include <util.h>
 #include <types.h>
+#include <thrust_wrapper.h>
 
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
@@ -616,7 +617,7 @@ void PMIS_Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         }  // num rows > 0
 
         // count # of points still unassigned
-        numUnassigned = (int) thrust::count(cf_map.begin(), cf_map.begin() + numRows, (int)UNASSIGNED);
+        numUnassigned = (int) thrust_wrapper::count(cf_map.begin(), cf_map.begin() + numRows, (int)UNASSIGNED);
         cudaCheckError();
         numUnassignedMax = numUnassigned;
         cudaCheckError();

--- a/core/src/energymin/interpolators/em.cu
+++ b/core/src/energymin/interpolators/em.cu
@@ -31,6 +31,7 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
+#include <thrust_wrapper.h>
 
 #include <energymin/interpolators/em.h>
 #include <energymin/interpolators/common.h>
@@ -743,7 +744,7 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
     IntVector PnzOffsets(numCoarse + 1);
     PnzOffsets[0] = 0;
     // get the offsets in P with an inclusive scan
-    thrust::inclusive_scan(PnnzPerCol.begin(), PnnzPerCol.end(), PnzOffsets.begin() + 1);
+    thrust_wrapper::inclusive_scan(PnnzPerCol.begin(), PnnzPerCol.end(), PnzOffsets.begin() + 1);
     cudaCheckError();
     // get total num of non-zeros in P
     const int Pnnz = PnzOffsets[numCoarse];
@@ -911,7 +912,7 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
     cudaCheckError();
     // 2. Resize Ma and assign MaRowOffsets by performing a scan on Ma_nnzPerRow.
     // Get the offsets in Ma with an inclusive scan (in-place)
-    thrust::inclusive_scan(Ma_nnzPerRow.begin(), Ma_nnzPerRow.end(), Ma_nnzPerRow.begin());
+    thrust_wrapper::inclusive_scan(Ma_nnzPerRow.begin(), Ma_nnzPerRow.end(), Ma_nnzPerRow.begin());
     cudaCheckError();
     // Get total num of non-zeros in Ma
     const int Ma_nnz = Ma_nnzPerRow[AnumRows - 1];
@@ -940,7 +941,7 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
 
         if (MaRowEnd - MaRowBegin > 1)
         {
-            thrust::sort( Ma.col_indices.begin() + Ma.row_offsets[MaRow],
+            thrust_wrapper::sort( Ma.col_indices.begin() + Ma.row_offsets[MaRow],
                           Ma.col_indices.begin() + Ma.row_offsets[MaRow + 1] );
         }
     }

--- a/core/src/matrix_coloring/coloring_utils.cu
+++ b/core/src/matrix_coloring/coloring_utils.cu
@@ -37,6 +37,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <error.h>
 #include <vector_thrust_allocator.h>
+#include <thrust_wrapper.h>
 
 #include <algorithm>
 
@@ -50,7 +51,7 @@ void coloring_histogram(int *out_hist_host, int num_rows, int max_color, int *ro
     if (false) //TODO: enable, since almost always faster
     {
         device_vector_alloc<int> histogram(num_rows);
-        thrust::sort(data, data + num_rows);
+        thrust_wrapper::sort(data, data + num_rows);
         cudaCheckError();
         thrust::counting_iterator<int> search_begin(0);
         thrust::upper_bound(data, data + num_rows,

--- a/core/src/matrix_coloring/greedy_min_max_2ring.cu
+++ b/core/src/matrix_coloring/greedy_min_max_2ring.cu
@@ -816,7 +816,7 @@ Greedy_Min_Max_2Ring_Matrix_Coloring<TemplateConfig<AMGX_device, V, M, I> >::col
         }
     }
 
-    this->m_num_colors = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
+    this->m_num_colors = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
     cudaCheckError();
 }
 

--- a/core/src/matrix_coloring/greedy_recolor.cu
+++ b/core/src/matrix_coloring/greedy_recolor.cu
@@ -42,6 +42,7 @@
 #include <thrust/binary_search.h>
 #include <memory_intrinsics.h>
 #include <thrust/replace.h>
+#include <thrust_wrapper.h>
 
 #include <algorithm>
 
@@ -1016,7 +1017,7 @@ Greedy_Recolor_MatrixColoring<TemplateConfig<AMGX_device, V, M, I> >::color_matr
             sorted_rows_by_color.resize(num_rows);
             //this->m_sorted_rows_by_color.resize(num_rows);
             thrust::sequence(sorted_rows_by_color.begin(), sorted_rows_by_color.end()); //useless sequence
-            thrust::sort_by_key(row_colors.begin(), row_colors.begin() + num_rows, sorted_rows_by_color.begin()); //useless read from sequence
+            thrust_wrapper::sort_by_key(row_colors.begin(), row_colors.begin() + num_rows, sorted_rows_by_color.begin()); //useless read from sequence
             cudaCheckError();
             IVector offsets_rows_per_color_d(this->m_num_colors + 1);
             thrust::lower_bound(row_colors.begin(),
@@ -1171,7 +1172,7 @@ Greedy_Recolor_MatrixColoring<TemplateConfig<AMGX_device, V, M, I> >::color_matr
     printf("MAXCOLOR ref=%d %d\n",max_colorg,max_color);
     if(max_colorg!=max_color)exit(1);*/
 #else
-    int max_color = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() );
+    int max_color = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() );
 #endif
     //printf("MAXCOLOR %d %d\n",max_color_gold,max_color);
     cudaCheckError();

--- a/core/src/matrix_coloring/min_max.cu
+++ b/core/src/matrix_coloring/min_max.cu
@@ -431,7 +431,7 @@ void MinMaxMatrixColoring<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         cudaCheckError();
     }
 
-    this->m_num_colors = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
+    this->m_num_colors = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
     cudaCheckError();
 }
 
@@ -513,7 +513,7 @@ void MinMaxMatrixColoring<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_in
         cudaCheckError();
     }
 
-    this->m_num_colors = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
+    this->m_num_colors = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
     cudaCheckError();
 #if 0
     std::cout << "Num colors=" << this->m_num_colors << std::endl;

--- a/core/src/matrix_coloring/min_max_2ring.cu
+++ b/core/src/matrix_coloring/min_max_2ring.cu
@@ -460,7 +460,7 @@ Min_Max_2Ring_Matrix_Coloring<TemplateConfig<AMGX_device, V, M, I> >::colorMatri
         cudaCheckError();
     }
 
-    this->m_num_colors = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
+    this->m_num_colors = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
     cudaCheckError();
 #if 0
     device_vector_alloc<int> error_found( 1, 0 );
@@ -806,7 +806,7 @@ Min_Max_2Ring_Matrix_Coloring<TemplateConfig<AMGX_device, V, M, I> >::color_step
         cudaCheckError();
     }
 
-    this->m_num_colors = thrust::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
+    this->m_num_colors = thrust_wrapper::reduce( this->m_row_colors.begin(), this->m_row_colors.begin() + num_rows, 0, thrust::maximum<int>() ) + 1;
 }
 
 

--- a/core/tests/matrix_coloring_test.cu
+++ b/core/tests/matrix_coloring_test.cu
@@ -220,7 +220,7 @@ void color_histogram(const Vector1 &row_colors, Vector2 &histogram)
     // copy input data (could be skipped if input is allowed to be modified)
     device_vector_alloc<ValueType> data(row_colors);
     // sort data to bring equal elements together
-    thrust::sort(data.begin(), data.end());
+    thrust_wrapper::sort(data.begin(), data.end());
     // number of histogram bins is equal to the maximum value plus one
     IndexType num_bins = data.back() + 1;
     // resize histogram storage


### PR DESCRIPTION
The thrust calls throughout the setup phase invoke cudaMalloc/cudaFree regularly, where all other memory allocations are managed through the custom AMGX memory manager.

This patch wraps all of those thrust calls such that the memory manager is passed through to thrust, avoiding the cudaMalloc/cudaFree calls.

Although the performance difference is minimal (roughly 3% on average), I think the other consequences of this patch are quite important, as it will enable future optimisations regarding asynchronous memory copies when you have multiple linear systems. 

In terms of the implementation, this is one approach, but if there is another less invasive approach I would be happy to change the implementation. 