### PR TITLE
Adjust automatic calculation of partition vector to use local row counts

### DIFF
--- a/base/src/distributed/distributed_manager.cu
+++ b/base/src/distributed/distributed_manager.cu
@@ -1169,22 +1169,16 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 
     if (partition == NULL)
     {
-        // initialize equal partitioning
-        IVector_h scanPartSize(num_ranks + 1);
+        IVector_h rowCounts(num_ranks);
+        this->getComms()->all_gather(num_rows, rowCounts, 1);
 
-        for (int p = 0; p < num_ranks; p++)
-        {
-            scanPartSize[p] = p * num_rows_global / num_ranks;
-        }
-
-        scanPartSize[num_ranks] = num_rows_global;
         int p = 0;
-
-        for (int i = 0; i < num_rows_global; i++)
+        for (int i = 0; i < num_ranks; ++i)
         {
-            if (i >= scanPartSize[p + 1]) { p++; }
-
-            partitionVec[i] = p;
+            for (int j = 0; j < rowCounts[i]; ++j)
+            {
+                partitionVec[p++] = i;
+            }
         }
     }
     else


### PR DESCRIPTION
As previously discussed, this introduces an additional scalar MPI_Allgather when calculating the automatic partition vector, to ensures that the distribution of ranks is relative to the number of rows locally contained within each rank.

I expect this would be the behaviour assumed by users given that each rank passes in the number of local rows. This approach still maintains the contiguous partitioning of the matrix on each rank. 

As far as I can see, it is incorrect to assume that if the number of rows per rank is imbalanced the user would expect the matrix to be "equally partitioned", as this is at odds with the number of local rows the user has given to each rank for ownership.

Given this, I see the original functionality as faulty and have replaced it in a fully breaking manner, but please let me know if you see some use case I missed.