### PR TITLE
CMake support for Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ if(NOT WIN32)
 endif()
 
 #Configuration specific nvcc flags
-if(CMAKE_COMPILER_IS_GNUCXX)
+GET_FILENAME_COMPONENT(CMAKE_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_NAME MATCHES "clang")
   set(CUDA_NVCC_FLAGS_DEBUG "-g;-G;-std=c++14;--Werror cross-execution-space-call;${NVTXRANGE_FLAG}" CACHE STRING "Debug compiler flags")
   set(CUDA_NVCC_FLAGS_RELEASE "-O3;-DNDEBUG;-std=c++14;--Werror cross-execution-space-call;${NVTXRANGE_FLAG}" CACHE STRING "Release compiler flags")
   set(CUDA_NVCC_FLAGS_PROFILE "-O3;-DPROFILE;-std=c++14;${NVTXRANGE_FLAG}" CACHE STRING "Profile compiler flags")
@@ -195,11 +196,11 @@ endif(AMGX_keep_intermediate)
 
 #windows/linux specific settings for C
 GET_FILENAME_COMPONENT(CMAKE_C_COMPILER_NAME "${CMAKE_C_COMPILER}" NAME)
-IF(CMAKE_C_COMPILER_NAME MATCHES cl)
+IF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" CACHE STRING "nvcc flags")
-ELSE(CMAKE_C_COMPILER_NAME MATCHES cl)
+ELSE(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler=-rdynamic;-Xcompiler=-fPIC;-Xcompiler=-fvisibility=default" CACHE STRING "nvcc flags")
-ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl)
+ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
 
 # VS: include object files in target property SOURCES
 # otherwise a workaround for extracting ${obj_all} is necessary below

--- a/eigen_examples/CMakeLists.txt
+++ b/eigen_examples/CMakeLists.txt
@@ -40,13 +40,13 @@ else(WIN32)
 endif(WIN32)
 
 GET_FILENAME_COMPONENT(CMAKE_C_COMPILER_NAME "${CMAKE_C_COMPILER}" NAME)
-IF(CMAKE_C_COMPILER_NAME MATCHES cl)
+IF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all ${cusparse_library} ${cusolver_library})
   set(dyn_libs amgxsh cudart.lib)
-ELSE(CMAKE_C_COMPILER_NAME MATCHES cl)
+ELSE(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all ${cusparse_library} ${cusolver_library} rt dl)
   set(dyn_libs amgxsh rt dl cudart)
-ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl)
+ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
 
 ADD_EXECUTABLE(eigensolver eigensolver.c)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -44,13 +44,13 @@ else(WIN32)
 endif(WIN32)
 
 GET_FILENAME_COMPONENT(CMAKE_C_COMPILER_NAME "${CMAKE_C_COMPILER}" NAME)
-IF(CMAKE_C_COMPILER_NAME MATCHES cl)
+IF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all ${cusparse_library} ${cusolver_library})
   set(dyn_libs amgxsh cudart.lib)
-ELSE(CMAKE_C_COMPILER_NAME MATCHES cl)
+ELSE(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all ${cusparse_library} ${cusolver_library} rt dl)
   set(dyn_libs amgxsh rt dl cudart)
-ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl)
+ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
 
 ADD_EXECUTABLE(amgx_capi amgx_capi.c)
 
@@ -149,4 +149,3 @@ install(TARGETS amgx_capi DESTINATION "lib/examples")
 if(MPI_FOUND)
   install(TARGETS amgx_mpi_capi amgx_mpi_capi_agg amgx_mpi_capi_cla amgx_mpi_poisson7 DESTINATION "lib/examples")
 endif(MPI_FOUND)
-


### PR DESCRIPTION
Some small changes to allow compilation with Clang - some logic that looks like it was intended to check for a Windows compiler was regex-matching "cl", which also picks up "clang".

`CMAKE_C_COMPILER_ID` and `CMAKE_CXX_COMPILER_ID` may also be useful, but I'm not sure if those are supported in CMake 2.8.0, which is AmgX's minimum CMake version.