### PR TITLE
Fix for multipass interpolation / aggressive coarsening

### DIFF
--- a/core/src/classical/interpolators/multipass.cu
+++ b/core/src/classical/interpolators/multipass.cu
@@ -773,7 +773,8 @@ compute_interp_weight_first_pass_kernel( const int A_num_rows,
 
             if ( lane_id == 0 )
             {
-                double div = (fabs(sum_C * diag[a_row_id]) < 1e-10) ? 1. : sum_C * diag[a_row_id];
+                // NOTE this matches the check for zero in HYPRE
+                double div = (fabs(sum_C * diag[a_row_id]) == 0.0) ? 1. : sum_C * diag[a_row_id];
                 alfa = -sum_N / div;
             }
 
@@ -967,7 +968,8 @@ compute_interp_weight_kernel( const int A_num_rows,
 
         if ( lane_id == 0 )
         {
-            double div = (fabs(sum_C * diag[a_row_id]) < 1e-10) ? 1. : sum_C * diag[a_row_id];
+            // NOTE this matches the check for zero in HYPRE
+            double div = (fabs(sum_C * diag[a_row_id]) == 0.0) ? 1. : sum_C * diag[a_row_id];
             alfa = -sum_N / div;
             // alfa = -sum_N/(sum_C*diag[a_row_id]);
         }


### PR DESCRIPTION
There is a bug in multipass interpolation that made aggressive coarsening wildly increase the number of iterations required for convergence in some problems.

This minor patch replaces tests for epsilon with checks for 0.0, which is the same approach as taken in HYPRE's multipass implementation.