### PR TITLE
Fix for reporting iteration count

### DIFF
--- a/base/src/amgx_c.cu
+++ b/base/src/amgx_c.cu
@@ -1936,7 +1936,7 @@ inline void solver_get_iterations_number(AMGX_solver_handle slv, int *n)
 {
     auto *solver = get_mode_object_from<CASE, AMG_Solver, AMGX_solver_handle>(slv);
     cudaSetDevice(solver->getResources()->getDevice(0));
-    *n = solver->get_num_iters() + 1;
+    *n = solver->get_num_iters();
 }
 
 template<AMGX_Mode CASE>


### PR DESCRIPTION
Resolves #126 

We noticed that the ``AMGX_solver_get_iterations_number()`` method reports 1 iteration more than what is reported on the terminal. This PR proposes  a fix. 