### PR TITLE
Fix for GMRES convergence bug

### DIFF
--- a/core/src/solvers/gmres_solver.cu
+++ b/core/src/solvers/gmres_solver.cu
@@ -393,13 +393,13 @@ GMRES_Solver<T_Config>::solve_iteration( VVector &b, VVector &x, bool xIsZero )
         // Call the preconditioner to get M^-1*(sum_m vm*ym), store in m_V_Vectors[0]
         if (no_preconditioner)
         {
-            copy( m_V_vectors[0], m_Z_vector, offset, size);
+            copy( m_Z_vector, m_V_vectors[0], offset, size);
         }
         else
         {
             m_V_vectors[0].delayed_send = 1;
             m_Z_vector.delayed_send = 1;
-            m_preconditioner->solve( m_V_vectors[0], m_Z_vector, true );
+            m_preconditioner->solve( m_Z_vector, m_V_vectors[0], true );
             m_V_vectors[0].delayed_send = 1;
             m_Z_vector.delayed_send = 1;
         }


### PR DESCRIPTION
Currently v2.1.x GMRES does not converge correctly. 

The copy/solve of the Z vector is the wrong way around in both branches of the new no_preconditioner check. I have swapped these back and this fixes the convergence issue. See reasoning:

L385: m_V_vectors[i] is currently filled with up to date data, m_Z_vectors is filled with zeroes

L390: axpy(x,y) y = ax + y, so m_V_vectors[j] is input (x) and m_Z_vectors output (y)

L396: copy(a, b) b = a, so m_V_vectors[0] must be output (b) and m_Z_vectors input (a)
or
L402: m_preconditioner->solve(b, x), so m_V_vectors[0] must be solution (x) and m_Z_vectors rhs (b)
