### PR TITLE
Fix compile error on Windows 10 with Visual Studio 2019 v16.9 

### DIFF
--- a/base/src/truncate.cu
+++ b/base/src/truncate.cu
@@ -575,7 +575,7 @@ void truncateAndScale_kernel(const IndexType *A_offsets, const IndexType *A_indi
         const int row_len = row_end - row_start;
         const int At_row_start = s_At_ptr[vector_lane][0];
         // mark & scan over consecutive blocks of 32 threads
-        int nloops = (int)ceil((float)row_len / THREADS_PER_VECTOR);
+        int nloops = (int)ceilf((float)row_len / THREADS_PER_VECTOR);
 #pragma unroll 2
 
         for (int i = 0; i < nloops; i++)


### PR DESCRIPTION
Hello, 

I was trying to build AMGX in release mode on Windows 10 with VS2019 v16.9 but got multiple errors like:
```
[build] E:/xiaoqi/AMGX/base/src/truncate.cu(578): error : calling a __host__ function("__ceilf") from a __global__ function("amgx::truncateAndScale_kernel<int, float, float, (int)128, (int)4> ") is not allowed [E:\xiaoqi\AMGX-2.2.0\build\base\amgx_base.vcxproj]
[build]   
[build] E:/xiaoqi/AMGX/base/src/truncate.cu(578): error : identifier "__ceilf" is undefined in device code [E:\xiaoqi\AMGX-2.2.0\build\base\amgx_base.vcxproj]
```
And going back to VS2017 got rid of the errors.

I searched for the issue and found that `<cmath>` started including a file called `intrin0.h` which has a cpu prototype for the `float ceil(float)`. That got selected as the best candidate while building and led to the error.
The build works with explicitly using `ceilf()` rather than `ceil()` with VS2019 v16.9.