### PR TITLE
Multiple optimisations and fixes related to OpenFOAM acceleration

### DIFF
--- a/base/include/amgx_cusparse.h
+++ b/base/include/amgx_cusparse.h
@@ -250,7 +250,14 @@ class Cusparse
                           Vector<TConfig> &Res);
 
 
+        template <class TConfig>
+        static void transpose(const Matrix<TConfig> &A, Matrix<TConfig> &B);
+
+        template <class TConfig>
+        static void transpose(const Matrix<TConfig> &A, Matrix<TConfig> &B, const int nRows, const int nNz);
+
     private:
+
         template <class TConfig>
         static void bsrmv_internal( typename TConfig::VecPrec alphaConst,
                                     const Matrix<TConfig> &A,

--- a/base/include/amgx_types/util.h
+++ b/base/include/amgx_types/util.h
@@ -117,6 +117,7 @@ struct util <float,  PODTypes<float>::type >
     static __host__ __device__ __inline__ float conjugate(const float &val) {return val;};
     static __host__ __device__ __inline__ void  invert_inplace(float &val) {val = -val;};
     static __host__ __device__ __inline__ void  conjugate_inplace(float &val) {};
+    static __host__ __device__ __inline__ void divide_by_integer(float& val, int64_t &denom) {val /= static_cast<float>(denom);};
 
     static __host__ __device__ __inline__ float abs (const float &val)
     {
@@ -168,6 +169,7 @@ struct util <double, PODTypes<double>::type>
     static __host__ __device__ __inline__ double conjugate(const double &val) {return val;};
     static __host__ __device__ __inline__ void invert_inplace(double &val) {val = -val;};
     static __host__ __device__ __inline__ void conjugate_inplace(double &val) {};
+    static __host__ __device__ __inline__ void divide_by_integer(double& val, int64_t &denom) {val /= static_cast<double>(denom);};
 
     static __host__ __device__ __inline__ double abs (const double &val)
     {
@@ -220,6 +222,12 @@ struct util <cuComplex, PODTypes<cuComplex>::type >
     static __host__ __device__ __inline__ cuComplex conjugate(const cuComplex &val) {return make_cuComplex(cuCrealf(val), -cuCimagf(val));};
     static __host__ __device__ __inline__ void invert_inplace(cuComplex &val) {val = make_cuComplex(-cuCrealf(val), -cuCimagf(val));};
     static __host__ __device__ __inline__ void conjugate_inplace(cuComplex &val) {val = make_cuComplex(cuCrealf(val), -cuCimagf(val));};
+    static __host__ __device__ __inline__ void divide_by_integer(cuComplex& val, int64_t &denom)
+    {
+        float den = static_cast<float>(denom);
+        val.x /= den;
+        val.y /= den;
+    };
 
     static __host__ __device__ __inline__ float abs (const cuComplex &val)
     {
@@ -294,6 +302,12 @@ struct util <cuDoubleComplex, PODTypes<cuDoubleComplex>::type>
     static __host__ __device__ __inline__ cuDoubleComplex conjugate(const cuDoubleComplex &val) {return make_cuDoubleComplex(cuCreal(val), -cuCimag(val));};
     static __host__ __device__ __inline__ void invert_inplace(cuDoubleComplex &val) {val =  make_cuDoubleComplex(-cuCreal(val), -cuCimag(val));};
     static __host__ __device__ __inline__ void conjugate_inplace(cuDoubleComplex &val) {val = make_cuDoubleComplex(cuCreal(val), -cuCimag(val));};
+    static __host__ __device__ __inline__ void divide_by_integer(cuDoubleComplex& val, int64_t &denom)
+    {
+        double den = static_cast<double>(denom);
+        val.x /= den;
+        val.y /= den;
+    };
 
     static __host__ __device__ __inline__ double abs (const cuDoubleComplex &val)
     {

--- a/base/include/distributed/comms_mpi_hostbuffer_stream.h
+++ b/base/include/distributed/comms_mpi_hostbuffer_stream.h
@@ -505,6 +505,12 @@ class CommsMPIHostBufferStream : public CommsMPI<T_Config>
         void all_gather_v(HIVector &my_data, HIVector &gathered_data, int num_parts);
         void all_reduce_max(IndexType_h &my_data, IndexType_h &result_data);
 
+        void all_gather_v(HDVector& data, int num_elems, HDVector& gathered_data, HIVector counts, HIVector displs);
+        void all_gather_v(HFVector& data, int num_elems, HFVector& gathered_data, HIVector counts, HIVector displs);
+        void all_gather_v(HCVector& data, int num_elems, HCVector& gathered_data, HIVector counts, HIVector displs);
+        void all_gather_v(HZVector& data, int num_elems, HZVector& gathered_data, HIVector counts, HIVector displs);
+        void all_gather_v(HIVector& data, int num_elems, HIVector& gathered_data, HIVector counts, HIVector displs);
+
 #ifdef AMGX_WITH_MPI
         const MPI_Comm &get_mpi_comm() const {return mpi_comm;}
 #endif

--- a/base/include/distributed/distributed_comms.h
+++ b/base/include/distributed/distributed_comms.h
@@ -338,6 +338,11 @@ class DistributedComms
 
         virtual void all_reduce_max(IndexType_h &my_data, IndexType_h &result_data) = 0;
 
+        virtual void all_gather_v(HDVector& data, int num_elems, HDVector& gathered_data, HIVector counts, HIVector displs) = 0;
+        virtual void all_gather_v(HFVector& data, int num_elems, HFVector& gathered_data, HIVector counts, HIVector displs) = 0;
+        virtual void all_gather_v(HCVector& data, int num_elems, HCVector& gathered_data, HIVector counts, HIVector displs) = 0;
+        virtual void all_gather_v(HZVector& data, int num_elems, HZVector& gathered_data, HIVector counts, HIVector displs) = 0;
+        virtual void all_gather_v(HIVector& data, int num_elems, HIVector& gathered_data, HIVector counts, HIVector displs) = 0;
 
 
         // Increment the reference counter.

--- a/base/include/getvalue.h
+++ b/base/include/getvalue.h
@@ -70,6 +70,10 @@ inline NormType getValue<NormType>(const char *name)
     {
         return L1;
     }
+    else if (strncmp(name, "L1_SCALED", 100) == 0)
+    {
+        return L1_SCALED;
+    }
     else if (strncmp(name, "L2", 100) == 0)
     {
         return L2;

--- a/base/include/norm.h
+++ b/base/include/norm.h
@@ -41,10 +41,13 @@ namespace amgx
  * Returns the norm of a vector
  *********************************************************/
 template<class VectorType, class MatrixType>
-typename types::PODTypes<typename VectorType::value_type>::type get_norm(const MatrixType &A, const VectorType &r, const NormType norm_type);
+typename types::PODTypes<typename VectorType::value_type>::type get_norm(const MatrixType &A, const VectorType &r, const NormType norm_type, typename types::PODTypes<typename VectorType::value_type>::type norm_factor = 1.0);
 
 template <class VectorType, class MatrixType, class PlainVectorType>
-void get_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm);
+void get_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm, typename types::PODTypes<typename VectorType::value_type>::type norm_factor = 1.0);
+
+template <class VectorType, class MatrixType>
+void compute_norm_factor(MatrixType &A, VectorType &b, VectorType &x, const NormType normType, typename types::PODTypes<typename VectorType::value_type>::type &normFactor);
 
 } // namespace amgx
 

--- a/base/include/sm_utils.inl
+++ b/base/include/sm_utils.inl
@@ -343,9 +343,7 @@ static __device__ __forceinline__ float shfl( float r, int lane, int bound = war
 static __device__ __forceinline__ double shfl( double r, int lane, int bound = warpSize, unsigned int mask = DEFAULT_MASK )
 {
 #if CUDART_VERSION >= 9000
-    int hi = __shfl_sync(mask, __double2hiint(r), lane, bound );
-    int lo = __shfl_sync(mask, __double2loint(r), lane, bound );
-    return __hiloint2double( hi, lo );
+    return __shfl_sync(mask, r, lane, bound );
 #else
     int hi = __shfl( __double2hiint(r), lane, bound );
     int lo = __shfl( __double2loint(r), lane, bound );
@@ -395,9 +393,7 @@ static __device__ __forceinline__ float shfl_xor( float r, int lane_mask, int bo
 static __device__ __forceinline__ double shfl_xor( double r, int lane_mask, int bound = warpSize, unsigned int mask = DEFAULT_MASK )
 {
 #if CUDART_VERSION >= 9000
-    int hi = __shfl_xor_sync( mask, __double2hiint(r), lane_mask, bound );
-    int lo = __shfl_xor_sync( mask, __double2loint(r), lane_mask, bound );
-    return __hiloint2double( hi, lo );
+    return __shfl_xor_sync( mask, r, lane_mask, bound );
 #else
     int hi = __shfl_xor( __double2hiint(r), lane_mask, bound );
     int lo = __shfl_xor( __double2loint(r), lane_mask, bound );
@@ -446,9 +442,7 @@ static __device__ __forceinline__ float shfl_down( float r, int offset, int boun
 static __device__ __forceinline__ double shfl_down( double r, int offset, int bound = warpSize, unsigned int mask = DEFAULT_MASK )
 {
 #if CUDART_VERSION >= 9000
-    int hi = __shfl_down_sync( mask, __double2hiint(r), offset, bound );
-    int lo = __shfl_down_sync( mask, __double2loint(r), offset, bound );
-    return __hiloint2double( hi, lo );
+    return __shfl_down_sync( mask, r, offset, bound );
 #else
     int hi = __shfl_down( __double2hiint(r), offset, bound );
     int lo = __shfl_down( __double2loint(r), offset, bound );
@@ -498,9 +492,7 @@ static __device__ __forceinline__ float shfl_up( float r, int offset, int bound 
 static __device__ __forceinline__ double shfl_up( double r, int offset, int bound = warpSize, unsigned int mask = DEFAULT_MASK )
 {
 #if CUDART_VERSION >= 9000
-    int hi = __shfl_up_sync( mask, __double2hiint(r), offset, bound );
-    int lo = __shfl_up_sync( mask, __double2loint(r), offset, bound );
-    return __hiloint2double( hi, lo );
+    return __shfl_up_sync( mask, r, offset, bound );
 #else
     int hi = __shfl_up( __double2hiint(r), offset, bound );
     int lo = __shfl_up( __double2loint(r), offset, bound );

--- a/base/include/solvers/solver.h
+++ b/base/include/solvers/solver.h
@@ -120,6 +120,7 @@ class Solver : public AuxData
         inline bool compute_norm_and_converged()
         {
             compute_norm();
+
             return converged();
         }
 
@@ -252,6 +253,7 @@ class Solver : public AuxData
         std::vector<PODVector_h> m_res_history;
         PODVector_h m_nrm;
         PODVector_h m_nrm_ini;
+        PODValueB m_norm_factor;
         bool m_use_scalar_norm;
 
         // Convergence object. To decide convergence.

--- a/base/include/types.h
+++ b/base/include/types.h
@@ -36,13 +36,16 @@ namespace amgx
 enum ASSIGNMENTS {COARSE = -1, FINE = -2, STRONG_FINE = -3, UNASSIGNED = -4};
 
 // NormType
-enum NormType {L1, L2, LMAX};
+enum NormType {L1, L1_SCALED, L2, LMAX};
 inline const char *getString(NormType p)
 {
     switch (p)
     {
         case L1:
             return "L1";
+
+        case L1_SCALED:
+            return "L1_SCALED";
 
         case L2:
             return "L2";

--- a/base/src/distributed/comms_mpi_hostbuffer_stream.cu
+++ b/base/src/distributed/comms_mpi_hostbuffer_stream.cu
@@ -1560,6 +1560,57 @@ void CommsMPIHostBufferStream<T_Config>::all_gather_v_templated(T &my_data, int 
 #endif
 }
 
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather_v(HDVector& data, int num_elems, HDVector& gathered_data, HIVector counts, HIVector displs)
+{
+#ifdef AMGX_WITH_MPI
+    MPI_Allgatherv(data.raw(), num_elems, MPI_DOUBLE, gathered_data.raw(), counts.raw(), displs.raw(), MPI_DOUBLE, mpi_comm);
+#else
+    FatalError("MPI Comms module requires compiling with MPI", AMGX_ERR_NOT_IMPLEMENTED);
+#endif
+}
+
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather_v(HFVector& data, int num_elems, HFVector& gathered_data, HIVector counts, HIVector displs)
+{
+#ifdef AMGX_WITH_MPI
+    MPI_Allgatherv(data.raw(), num_elems, MPI_FLOAT, gathered_data.raw(), counts.raw(), displs.raw(), MPI_FLOAT, mpi_comm);
+#else
+    FatalError("MPI Comms module requires compiling with MPI", AMGX_ERR_NOT_IMPLEMENTED);
+#endif
+}
+
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather_v(HCVector& data, int num_elems, HCVector& gathered_data, HIVector counts, HIVector displs)
+{
+#ifdef AMGX_WITH_MPI
+    FatalError("AllgatherV with complex data.", AMGX_ERR_NOT_IMPLEMENTED);
+#else
+    FatalError("MPI Comms module requires compiling with MPI", AMGX_ERR_NOT_IMPLEMENTED);
+#endif
+}
+
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather_v(HZVector& data, int num_elems, HZVector& gathered_data, HIVector counts, HIVector displs)
+{
+#ifdef AMGX_WITH_MPI
+    FatalError("AllgatherV with complex data.", AMGX_ERR_NOT_IMPLEMENTED);
+#else
+    FatalError("MPI Comms module requires compiling with MPI", AMGX_ERR_NOT_IMPLEMENTED);
+#endif
+}
+
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather_v(HIVector& data, int num_elems, HIVector& gathered_data, HIVector counts, HIVector displs)
+{
+#ifdef AMGX_WITH_MPI
+    MPI_Allgatherv(data.raw(), num_elems, MPI_INT, gathered_data.raw(), counts.raw(), displs.raw(), MPI_INT, mpi_comm);
+#else
+    FatalError("MPI Comms module requires compiling with MPI", AMGX_ERR_NOT_IMPLEMENTED);
+#endif
+}
+
+
 /****************************************
  * Explict instantiations
  ***************************************/

--- a/base/src/matrix.cu
+++ b/base/src/matrix.cu
@@ -246,7 +246,7 @@ void
 Matrix< TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::apply(const Vector<TConfig> &v, Vector<TConfig> &res, ViewType view)
 {
     Vector<TConfig> &v_ = const_cast<Vector<TConfig>&>(v);
-    multiply(*this, v_, res);
+    multiply(*this, v_, res, view);
 }
 
 

--- a/base/src/multiply.cu
+++ b/base/src/multiply.cu
@@ -117,7 +117,7 @@ void multiply(Matrix<TConfig> &A, Vector<TConfig> &B, Vector<TConfig> &C, ViewTy
     typedef Matrix<TConfig> TMatrix;
     typedef Vector<TConfig> TVector;
 
-    bool latencyHiding = (A.getViewInterior() != A.getViewExterior() && !A.is_matrix_singleGPU() && B.dirtybit != 0);
+    bool latencyHiding = (view == A.getViewExterior() && A.getViewInterior() != A.getViewExterior() && !A.is_matrix_singleGPU() && B.dirtybit != 0);
 
     if (latencyHiding)
     {
@@ -135,12 +135,12 @@ void multiply(Matrix<TConfig> &A, Vector<TConfig> &B, Vector<TConfig> &C, ViewTy
     }
     else
     {
-        if (!A.is_matrix_singleGPU() && B.dirtybit != 0)
+        if (view != INTERIOR && !A.is_matrix_singleGPU() && B.dirtybit != 0)
         {
             A.manager->exchange_halo_v2(B, B.tag);
         }
 
-        multiply_block_size(A, B, C, A.getViewExterior());
+        multiply_block_size(A, B, C, view);
     }
 
     C.dirtybit = 1;

--- a/base/src/norm.cu
+++ b/base/src/norm.cu
@@ -43,7 +43,9 @@
 #include <thrust/sort.h>
 #include "strided_reduction.h"
 
+#include "amgx_timer.h"
 #include "amgx_types/util.h"
+#include "thrust_wrapper.h"
 
 namespace amgx
 {
@@ -53,54 +55,56 @@ namespace amgx
  *********************************************************/
 
 template<class VectorType, class MatrixType>
-typename types::PODTypes<typename VectorType::value_type>::type get_norm(const MatrixType &A, const VectorType &r, const NormType norm_type)
+typename types::PODTypes<typename VectorType::value_type>::type get_norm(const MatrixType &A, const VectorType &r, const NormType norm_type, typename types::PODTypes<typename VectorType::value_type>::type norm_factor)
 {
     typedef typename types::PODTypes<typename VectorType::value_type>::type value_type;
     value_type nrm;
     int offset, size;
     A.getOffsetAndSizeForView(OWNED, &offset, &size);
 
-    switch (norm_type)
+    if (norm_type == L1 || norm_type == L1_SCALED)
     {
-        case L1:
-            nrm = nrm1(r, offset, size);
+        nrm = nrm1(r, offset, size);
 
-            if (A.is_matrix_distributed())
+        if (A.is_matrix_distributed())
+        {
+            A.getManager()->global_reduce_sum(&nrm);
+        }
+
+        return (norm_type == L1_SCALED) ? nrm / norm_factor : nrm;
+    }
+    else if (norm_type == L2)
+    {
+        nrm = nrm2(r, offset, size);
+
+        if (A.is_matrix_distributed())
+        {
+            nrm = nrm * nrm;
+            A.getManager()->global_reduce_sum(&nrm);
+            nrm = sqrt(nrm);
+        }
+    }
+    else if (norm_type == LMAX)
+    {
+        nrm = nrmmax(r, offset, size);
+
+        if (A.is_matrix_distributed())
+        {
+            typedef TemplateConfig<AMGX_host, types::PODTypes<typename VectorType::value_type>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> hvector_type;
+            typedef Vector<hvector_type> HVector;
+            //collect values from all neighbors, and do the "reduction" part
+            std::vector<HVector> values(0);
+            HVector my_nrm(1);
+            my_nrm[0] = nrm;
+            A.getManager()->getComms()->global_reduce(values, my_nrm, A, 3);
+
+            for (int j = 0; j < values.size(); j++)
             {
-                A.getManager()->global_reduce_sum(&nrm);
+                nrm = (nrm > values[j][0] ? nrm : values[j][0]);
             }
+        }
 
-            return nrm;
-
-        case L2:
-            nrm = nrm2(r, offset, size);
-
-            if (A.is_matrix_distributed())
-            {
-                nrm = nrm * nrm;
-                A.getManager()->global_reduce_sum(&nrm);
-                nrm = sqrt(nrm);
-            }
-
-            return nrm;
-
-        case LMAX:
-            nrm = nrmmax(r, offset, size);
-
-            if (A.is_matrix_distributed())
-            {
-                typedef TemplateConfig<AMGX_host, types::PODTypes<typename VectorType::value_type>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> hvector_type;
-                typedef Vector<hvector_type> HVector;
-                //collect values from all neighbors, and do the "reduction" part
-                std::vector<HVector> values(0);
-                HVector my_nrm(1);
-                my_nrm[0] = nrm;
-                A.getManager()->getComms()->global_reduce(values, my_nrm, A, 3);
-
-                for (int j = 0; j < values.size(); j++) { nrm = (nrm > values[j][0] ? nrm : values[j][0]); }
-            }
-
-            return nrm;
+        return nrm;
     }
 
     return -1;
@@ -110,9 +114,9 @@ template <class VectorType, class MatrixType, class PlainVectorType>
 class Norm_1x1;
 
 template <class VectorType, class MatrixType, class PlainVectorType>
-void get_1x1_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm)
+void get_1x1_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm, typename types::PODTypes<typename VectorType::value_type>::type norm_factor)
 {
-    Norm_1x1<VectorType, MatrixType, PlainVectorType>::get_1x1_norm(A, r, block_size, norm_type, block_nrm);
+    Norm_1x1<VectorType, MatrixType, PlainVectorType>::get_1x1_norm(A, r, block_size, norm_type, block_nrm, norm_factor);
 }
 
 template <AMGX_MemorySpace t_memSpace, AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec, class MatrixType, AMGX_VecPrecision t_pod_vecPrec >
@@ -125,7 +129,7 @@ class Norm_1x1< Vector<TemplateConfig<t_memSpace, t_vecPrec, t_matPrec, t_indPre
         typedef TemplateConfig<AMGX_host, types::PODTypes<ValueTypeB>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> hvector_type; // TConfig host with pod-values for ValueTypeB
         typedef Vector<hvector_type> HVector; //vectors for saving norms from allgather
 
-        static void get_1x1_norm(const MatrixType &A, const Vector_h &r, const int block_size, const NormType norm_type, PODHostVec &block_nrm)
+        static void get_1x1_norm(const MatrixType &A, const Vector_h &r, const int block_size, const NormType norm_type, PODHostVec &block_nrm, typename types::PODTypes<ValueTypeB>::type norm_factor)
         {
             //collect values from all neighbors, and do the "reduction" part
             std::vector<PODHostVec> values(0);
@@ -134,53 +138,63 @@ class Norm_1x1< Vector<TemplateConfig<t_memSpace, t_vecPrec, t_matPrec, t_indPre
             double sum = 0.l;
             A.getOffsetAndSizeForView(OWNED, &offset, &size);
 
-            switch (norm_type)
+            if (norm_type == L1 || norm_type == L1_SCALED)
             {
-                case L1:
-                    block_nrm[0] = nrm1(r, offset, size);
+                block_nrm[0] = nrm1(r, offset, size);
 
-                    if (A.is_matrix_distributed())
+                if (A.is_matrix_distributed())
+                {
+                    A.getManager()->getComms()->global_reduce(values, block_nrm, A, 4);
+                    block_nrm[0] = 0;
+
+                    for (int j = 0; j < values.size(); j++)
                     {
-                        A.getManager()->getComms()->global_reduce(values, block_nrm, A, 4);
-                        block_nrm[0] = 0;
-
-                        for (int j = 0; j < values.size(); j++) { sum += values[j][0]; }
-
-                        block_nrm[0] = sum;
+                        sum += values[j][0];
                     }
 
-                    break;
+                    block_nrm[0] = sum;
+                }
 
-                case L2:
-                    block_nrm[0] = nrm2(r, offset, size);
+                if (norm_type == L1_SCALED)
+                {
+                    block_nrm[0] /= norm_factor;
+                }
+            }
+            else if (norm_type == L2)
+            {
+                block_nrm[0] = nrm2(r, offset, size);
 
-                    if (A.is_matrix_distributed())
+                if (A.is_matrix_distributed())
+                {
+                    block_nrm[0] *= block_nrm[0];
+                    A.getManager()->getComms()->global_reduce(values, block_nrm, A, 5);
+                    block_nrm[0] = 0;
+
+                    for (int j = 0; j < values.size(); j++)
                     {
-                        block_nrm[0] *= block_nrm[0];
-                        A.getManager()->getComms()->global_reduce(values, block_nrm, A, 5);
-                        block_nrm[0] = 0;
-
-                        for (int j = 0; j < values.size(); j++) { sum += values[j][0]; }
-
-                        block_nrm[0] = sqrt(sum);
+                        sum += values[j][0];
                     }
 
-                    break;
+                    block_nrm[0] = sqrt(sum);
+                }
+            }
+            else if (norm_type == LMAX)
+            {
+                block_nrm[0] = nrmmax(r, offset, size);
 
-                case LMAX:
-                    block_nrm[0] = nrmmax(r, offset, size);
+                if (A.is_matrix_distributed())
+                {
+                    A.getManager()->getComms()->global_reduce(values, block_nrm, A, 6);
 
-                    if (A.is_matrix_distributed())
+                    for (int j = 0; j < values.size(); j++)
                     {
-                        A.getManager()->getComms()->global_reduce(values, block_nrm, A, 6);
-
-                        for (int j = 0; j < values.size(); j++) { block_nrm[0] = (block_nrm[0] > values[j][0] ? block_nrm[0] : values[j][0]); }
+                        block_nrm[0] = (block_nrm[0] > values[j][0] ? block_nrm[0] : values[j][0]);
                     }
-
-                    break;
-
-                default:
-                    FatalError("Normtype is not supported in get_1x1_norm", AMGX_ERR_NOT_IMPLEMENTED);
+                }
+            }
+            else
+            {
+                FatalError("Normtype is not supported in get_1x1_norm", AMGX_ERR_NOT_IMPLEMENTED);
             }
         };
 };
@@ -189,9 +203,9 @@ template <class Vector, class MatrixType, class PlainVectorType>
 class Norm_Square;
 
 template <class VectorType, class MatrixType, class PlainVectorType>
-void get_sq_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm)
+void get_sq_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm, typename types::PODTypes<typename VectorType::value_type>::type norm_factor)
 {
-    Norm_Square<VectorType, MatrixType, PlainVectorType>::get_sq_norm(A, r, block_size, norm_type, block_nrm);
+    Norm_Square<VectorType, MatrixType, PlainVectorType>::get_sq_norm(A, r, block_size, norm_type, block_nrm, norm_factor);
 }
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec, class MatrixType, AMGX_VecPrecision t_pod_vecPrec >
@@ -203,14 +217,14 @@ class Norm_Square<Vector<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPr
         typedef TemplateConfig<AMGX_host, types::PODTypes<ValueTypeB>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> hvector_type; // TConfig host with pod-values for ValueTypeB
         typedef Vector<hvector_type> HVector; //vectors for saving norms from allgather
 
-        static void get_sq_norm(const MatrixType &A, const Vector_h &r, const int block_size, const NormType norm_type, HVector &block_nrm)
+        static void get_sq_norm(const MatrixType &A, const Vector_h &r, const int block_size, const NormType norm_type, HVector &block_nrm, typename types::PODTypes<ValueTypeB>::type  norm_factor)
         {
             int bsize = block_nrm.size();
             int offset, size;
             A.getOffsetAndSizeForView(OWNED, &offset, &size);
             std::vector <double> norm(block_size, 0.l);
 
-            if (norm_type == L1)
+            if (norm_type == L1 || norm_type == L1_SCALED)
             {
                 if ( (size * r.get_block_size()) % bsize != 0)
                 {
@@ -251,7 +265,7 @@ class Norm_Square<Vector<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPr
 
                 for (int j = 0; j < bsize; j++)
                 {
-                    block_nrm[j] = norm[j];
+                    block_nrm[j] = (norm_type == L1_SCALED) ? norm[j] / norm_factor : norm[j];
                 }
             }
             else if (norm_type == L2)
@@ -321,7 +335,7 @@ class Norm_Square<Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         typedef typename Vector_h::value_type ValueTypeB; // vector's valuetype
         typedef TemplateConfig<AMGX_host, types::PODTypes<ValueTypeB>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> hvector_type; // TConfig host with pod-values for ValueTypeB
         typedef Vector<hvector_type> HVector; //vectors for saving norms from allgather
-        static void get_sq_norm(const MatrixType &A, const Vector_d &r, const int block_size, const NormType norm_type, HVector &block_nrm)
+        static void get_sq_norm(const MatrixType &A, const Vector_d &r, const int block_size, const NormType norm_type, HVector &block_nrm, typename types::PODTypes<ValueTypeB>::type norm_factor)
         {
             int bsize = block_nrm.size();
             int offset, size;
@@ -333,7 +347,7 @@ class Norm_Square<Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
                 FatalError("Size of vector r must be multiple of block size", AMGX_ERR_BAD_PARAMETERS);
             }
 
-            if (norm_type == L1)
+            if (norm_type == L1 || norm_type == L1_SCALED)
             {
                 amgx::strided_reduction::reduction_generic_dispatch(
                     bsize,
@@ -354,6 +368,14 @@ class Norm_Square<Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
                         {
                             block_nrm[i] += values[j][i];
                         }
+                    }
+                }
+
+                if (norm_type == L1_SCALED)
+                {
+                    for (int i = 0; i < block_nrm.size(); ++i)
+                    {
+                        block_nrm[i] /= norm_factor;
                     }
                 }
             }
@@ -404,24 +426,165 @@ class Norm_Square<Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
 };
 
 template<class VectorType, class MatrixType, class PlainVectorType>
-void get_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm)
+void get_norm(const MatrixType &A, const VectorType &r, const int block_size, const NormType norm_type, PlainVectorType &block_nrm, typename types::PODTypes<typename VectorType::value_type>::type norm_factor)
 {
     if (block_size == 1)
     {
-        get_1x1_norm(A, r, block_size, norm_type, block_nrm);
+        get_1x1_norm(A, r, block_size, norm_type, block_nrm, norm_factor);
     }
     else
     {
-        get_sq_norm(A, r, block_size, norm_type, block_nrm);
+        get_sq_norm(A, r, block_size, norm_type, block_nrm, norm_factor);
     }
 }
 
-#define AMGX_CASE_LINE(CASE) template typename types::PODTypes< typename Vector<TemplateMode<CASE>::Type>::value_type>::type  get_norm(const Matrix<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const NormType norm_type);
+template <class VectorType, class MatrixType>
+class Norm_Factor;
+
+template <class VectorType, class MatrixType>
+void compute_norm_factor(MatrixType &A, VectorType &b, VectorType &x, const NormType normType, typename types::PODTypes<typename VectorType::value_type>::type &normFactor)
+{
+    if(normType == L1_SCALED)
+    {
+        Norm_Factor<VectorType, MatrixType>::compute_norm_factor(A, b, x, normFactor);
+    }
+}
+
+template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec, class MatrixType >
+class Norm_Factor<Vector<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec> >, MatrixType>
+{
+    public:
+        typedef Vector<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec> > Vector_h;
+        typedef typename Vector_h::value_type ValueTypeVec;
+        typedef typename types::PODTypes<ValueTypeVec>::type ValueTypeNorm;
+
+        static void compute_norm_factor(MatrixType &A, Vector_h &b, Vector_h &x, ValueTypeNorm& normFactor)
+        {
+            FatalError("L1 scaled norm not supported with host execution.", AMGX_ERR_NOT_IMPLEMENTED);
+        }
+};
+
+template<int warpSize, class ValueTypeMat, class IndexTypeVec, class ValueTypeVec, class ValueTypeNorm>
+__global__ void scaled_norm_factor_calc(
+    int nRows, ValueTypeMat *Avals, IndexTypeVec *Arows, ValueTypeVec *Ax, ValueTypeVec *b, ValueTypeVec xAvg, ValueTypeNorm *localNormFactor)
+{
+    int r = threadIdx.x + blockIdx.x * blockDim.x;
+
+    __shared__ ValueTypeNorm normFactor_s;
+    if(threadIdx.x == 0)
+    {
+        normFactor_s = amgx::types::util<ValueTypeNorm>::get_zero();
+    }
+
+    ValueTypeNorm normFactor = 0.0;
+
+    if (r < nRows)
+    {
+        ValueTypeMat Arow_sum = amgx::types::util<ValueTypeMat>::get_zero();
+
+        // Read in the row
+#pragma unroll
+        for (int i = Arows[r]; i < Arows[r + 1]; ++i)
+        {
+            Arow_sum = Arow_sum + Avals[i];
+        }
+
+        normFactor =
+            types::util<ValueTypeVec>::abs(Ax[r] - Arow_sum * xAvg) +
+            types::util<ValueTypeVec>::abs(b[r] - Arow_sum * xAvg);
+    }
+
+    // Ensure normFactor_s is initialised
+    __syncthreads();
+
+    // Warp-local reduction to lane 0
+    for(int i = warpSize/2; i > 0; i /= 2)
+    {
+        normFactor += utils::shfl_down(normFactor, i);
+    }
+
+    // Fast shared atomic add by lane 0 of each warp
+    int laneId = threadIdx.x % warpSize;
+    if(laneId == 0)
+    {
+        utils::atomic_add(&normFactor_s, normFactor);
+    }
+
+    // Ensure normFactor_s is final
+    __syncthreads();
+
+    // Final output of normFactor by first thread of each block
+    if(threadIdx.x == 0)
+    {
+        utils::atomic_add(localNormFactor, normFactor_s);
+    }
+}
+
+template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec, class MatrixType>
+class Norm_Factor<Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >, MatrixType>
+{
+    public:
+        typedef Vector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> > Vector_d;
+        typedef typename Vector_d::value_type ValueTypeVec;
+        typedef typename Vector_d::index_type IndexTypeVec;
+        typedef typename types::PODTypes<ValueTypeVec>::type ValueTypeNorm;
+        typedef TemplateConfig<AMGX_device, types::PODTypes<ValueTypeVec>::vec_prec, MatrixType::TConfig::matPrec, MatrixType::TConfig::indPrec> NormVectorType;
+        typedef Vector<NormVectorType> NVector_d;
+
+        static void compute_norm_factor(MatrixType &A, Vector_d &b, Vector_d &x, ValueTypeNorm &normFactor)
+        {
+            if (A.get_block_dimx() != 1 || A.get_block_dimy() != 1)
+            {
+                FatalError("L1 scaled norm only supported with scalar matrices", AMGX_ERR_NOT_IMPLEMENTED);
+            }
+
+            // Calculate Ax
+            int offset, nRows;
+            A.getOffsetAndSizeForView(OWNED, &offset, &nRows);
+
+            Vector_d Ax(nRows);
+            A.apply(x, Ax);
+
+            // Calculate global average x
+            ValueTypeVec xAvg = thrust::reduce(x.begin(), x.begin() + nRows, amgx::types::util<ValueTypeVec>::get_zero());
+            A.manager->global_reduce_sum(&xAvg);
+            amgx::types::util<ValueTypeVec>::divide_by_integer(xAvg, A.manager->num_rows_global);
+
+            // Make a copy of b
+            Vector_d bTmp(b);
+
+            // Calculate row sums then the local norm factors
+            constexpr int nThreads = 128;
+            constexpr int warpSize = 32;
+            const int nBlocks = nRows/nThreads + 1;
+            NVector_d localNormFactor(1, amgx::types::util<ValueTypeNorm>::get_zero());
+            scaled_norm_factor_calc<warpSize><<<nBlocks, nThreads>>>(
+                nRows,
+                A.values.raw(),
+                A.row_offsets.raw(),
+                Ax.raw(),
+                bTmp.raw(),
+                xAvg,
+                localNormFactor.raw());
+
+            // Fetch the normFactor result and reduce across all ranks
+            normFactor = localNormFactor[0];
+            A.manager->global_reduce_sum(&normFactor);
+
+            // Print the norm factor
+            std::stringstream info;
+            info.precision(12);
+            info << "\tAmgX Scaled Norm Factor: " << std::scientific << normFactor << "\n";
+            amgx_output(info.str().c_str(), info.str().length());
+        }
+};
+
+#define AMGX_CASE_LINE(CASE) template typename types::PODTypes< typename Vector<TemplateMode<CASE>::Type>::value_type>::type get_norm(const Matrix<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const NormType norm_type, typename types::PODTypes<typename Vector<TemplateMode<CASE>::Type>::value_type>::type norm_factor);
 AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
 AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #undef AMGX_CASE_LINE
 
-#define AMGX_CASE_LINE(CASE) template typename types::PODTypes< typename Vector<TemplateMode<CASE>::Type>::value_type>::type get_norm(const Operator<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const NormType norm_type);
+#define AMGX_CASE_LINE(CASE) template typename types::PODTypes< typename Vector<TemplateMode<CASE>::Type>::value_type>::type get_norm(const Operator<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const NormType norm_type, typename types::PODTypes<typename Vector<TemplateMode<CASE>::Type>::value_type>::type norm_factor);
 AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
 AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #undef AMGX_CASE_LINE
@@ -429,7 +592,8 @@ AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #define AMGX_CASE_LINE(CASE) \
   typedef typename Vector< TemplateMode<CASE>::Type >::value_type ValueTypeMB##CASE ;\
   typedef TemplateMode<CASE>::Type::template setMemSpace<AMGX_host>::Type::template setVecPrec< types::PODTypes< ValueTypeMB##CASE >::vec_prec >::Type CurTConfigMB_h##CASE ;\
-  template void get_norm(const Matrix<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const int block_size, const NormType norm_type, Vector< CurTConfigMB_h##CASE >& block_nrm);
+  template void get_norm(const Matrix<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const int block_size, const NormType norm_type, Vector< CurTConfigMB_h##CASE >& block_nrm, typename types::PODTypes<typename Vector<TemplateMode<CASE>::Type>::value_type>::type norm_factor); \
+  template void compute_norm_factor(Matrix<TemplateMode<CASE>::Type> &A, Vector<TemplateMode<CASE>::Type> &b, Vector<TemplateMode<CASE>::Type> &x, const NormType normType, typename types::PODTypes<typename Vector<TemplateMode<CASE>::Type>::value_type>::type &normFactor);
 AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
 AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #undef AMGX_CASE_LINE
@@ -437,7 +601,7 @@ AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #define AMGX_CASE_LINE(CASE) \
   typedef typename Vector< TemplateMode<CASE>::Type >::value_type ValueTypeOB##CASE ;\
   typedef TemplateMode<CASE>::Type::template setMemSpace<AMGX_host>::Type::template setVecPrec< types::PODTypes< ValueTypeOB##CASE >::vec_prec >::Type CurTConfigOB_h##CASE ;\
-  template void get_norm(const Operator<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const int block_size, const NormType norm_type, Vector< CurTConfigOB_h##CASE >& block_nrm);
+  template void get_norm(const Operator<TemplateMode<CASE>::Type>& A, const Vector<TemplateMode<CASE>::Type>& r, const int block_size, const NormType norm_type, Vector< CurTConfigOB_h##CASE >& block_nrm, typename types::PODTypes<typename Vector<TemplateMode<CASE>::Type>::value_type>::type norm_factor);
 AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
 AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
 #undef AMGX_CASE_LINE

--- a/base/src/transpose.cu
+++ b/base/src/transpose.cu
@@ -77,10 +77,16 @@ void transpose(const Matrix &A, Matrix &B)
     else
     {
         B.addProps(CSR);
+        B.set_allow_recompute_diag(false);
+
+#ifdef ENABLE_CUSPARSE_TRANSPOSE
+        Cusparse::transpose(A, B);
+#else
         MatrixCusp<typename Matrix::TConfig, cusp::csr_format> wA((Matrix *) &A);
         MatrixCusp<typename Matrix::TConfig, cusp::csr_format> wB(&B);
-        B.set_allow_recompute_diag(false);
         cusp::transpose(wA, wB);
+#endif
+
         B.set_allow_recompute_diag(true);
         cudaCheckError();
         B.computeDiagonal();
@@ -105,13 +111,21 @@ void transpose(const Matrix &A, Matrix &B, int num_rows)
     }
 
     B.addProps(CSR);
+    B.set_allow_recompute_diag(false);
+
+#if ENABLE_CUSPARSE_TRANSPOSE
+    int num_nz = A.row_offsets[num_rows];
+    B.resize(A.get_num_cols(), num_rows, num_nz);
+    Cusparse::transpose(A, B, num_rows, num_nz);
+#else
     MatrixCusp<typename Matrix::TConfig, cusp::csr_format> wA((Matrix *) &A);
     MatrixCusp<typename Matrix::TConfig, cusp::csr_format> wB(&B);
-    B.set_allow_recompute_diag(false);
+
     // operate on wA / wB
     typedef typename Matrix::index_type   IndexType;
     typedef typename Matrix::value_type   ValueType;
     typedef typename Matrix::memory_space MemorySpace;
+
     int num_entries = A.row_offsets[num_rows];
     int num_cols = A.get_num_cols();
     // resize matrix
@@ -133,6 +147,7 @@ void transpose(const Matrix &A, Matrix &B, int num_rows)
         cusp::detail::sort_by_row(wB_row_indices, wB.column_indices, wB.values);
         cusp::detail::indices_to_offsets(wB_row_indices, wB.row_offsets);
     }
+#endif
 
     B.set_allow_recompute_diag(true);
     cudaCheckError();

--- a/core/include/solvers/dense_lu_solver.h
+++ b/core/include/solvers/dense_lu_solver.h
@@ -88,8 +88,15 @@ class DenseLUSolver<TemplateConfig<AMGX_device, V, M, I> >
 
         typedef Solver<TemplateConfig<AMGX_device, V, M, I> > Base;
         typedef TemplateConfig<AMGX_device, V, M, I> Config_d;
+        typedef TemplateConfig<AMGX_host, V, M, I> Config_h;
         typedef Matrix<Config_d> Matrix_d;
+        typedef Matrix<Config_h> Matrix_h;
         typedef Vector<Config_d> Vector_d;
+        typedef Vector<Config_d> Vector_h;
+        typedef typename Matrix_d::IVector IVector_d;
+        typedef typename Matrix_h::IVector IVector_h;
+        typedef typename Matrix_d::MVector MVector_d;
+        typedef typename Matrix_h::MVector MVector_h;
         typedef typename MatPrecisionMap<M>::Type Matrix_data;
         typedef typename VecPrecisionMap<V>::Type Vector_data;
 
@@ -112,10 +119,20 @@ class DenseLUSolver<TemplateConfig<AMGX_device, V, M, I> >
         cusolverDnHandle_t m_cuds_handle;
         cublasHandle_t m_cublas_handle;
         int m_num_rows, m_num_cols, m_lda;
+        int m_nnz_global;
         Matrix_data *m_dense_A;   // store sparse as dense
         int *m_ipiv;              // The pivot sequence from getrf()
         int *m_cuds_info;         // host pointer for debug info from getrf()
         Matrix_data *m_trf_wspace; // workspace for trf/trs
+        bool m_enable_exact_solve = false;
+
+        // Cached in the case of an exact coarse solve
+        IVector_h nz_all;
+        IVector_h nz_displs;
+        IVector_h row_all;
+        IVector_h row_displs;
+        IVector_d Acols_global;
+        IVector_d Arows_global;
 
         void csr_to_dense(); // Pack a CSR matrix to a dense matrix
         void cudense_getrf(); // LU decomposition

--- a/core/src/aggregation/aggregation_amg_level.cu
+++ b/core/src/aggregation/aggregation_amg_level.cu
@@ -1566,7 +1566,7 @@ void Aggregation_AMG_Level_Base<T_Config>::prepareNextLevelMatrix_none(const Mat
         Ac.manager->inverse_renumbering.resize(c_size);
         //get coarse -> fine renumbering
         int num_blocks = min(4096, (c_size + 127) / 128);
-        coarse_to_global <<< num_blocks, 128>>>(this->m_aggregates.raw(), this->m_aggregates_fine_idx.raw(), Ac.manager->inverse_renumbering.raw(), f_size, -1 * A.manager->base_index());
+        coarse_to_global <<< num_blocks, 128>>>(this->m_aggregates.raw(), this->m_aggregates_fine_idx.raw(), Ac.manager->inverse_renumbering.raw(), f_size, 0);
         cudaCheckError();
         Ac.manager->set_num_halo_rows(Ac.manager->halo_offsets[Ac.manager->halo_offsets.size() - 1] - c_size);
         Ac.set_initialized(1);

--- a/core/src/classical/interpolators/multipass.cu
+++ b/core/src/classical/interpolators/multipass.cu
@@ -1033,7 +1033,7 @@ template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrec
 Multipass_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::~Multipass_Interpolator()
 {}
 
-enum { WARP_SIZE = 32, GRID_SIZE = 128, SMEM_SIZE = 128 };
+enum { WARP_SIZE = 32, GRID_SIZE = 1024, SMEM_SIZE = 128 };
 
 
 struct is_less_than_zero
@@ -1195,7 +1195,7 @@ void Multipass_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_
     // ----------------------------------------------------------
     // Create an upper bound for the length of each row P
     // ----------------------------------------------------------
-    Hash_Workspace<TConfig_d, int64_t> exp_wk;
+    Hash_Workspace<TConfig_d, int64_t> exp_wk(true, GRID_SIZE);
     {
         const int CTA_SIZE  = 256;
         const int NUM_WARPS = CTA_SIZE / WARP_SIZE;

--- a/core/src/classical/strength/affinity.cu
+++ b/core/src/classical/strength/affinity.cu
@@ -485,7 +485,7 @@ computeStrongConnectionsAndWeights_1x1(Matrix_d &A,
     // choose a blocksize. Use 1 warp per row
     const int blockSize = 256;
     const int numWarps  = blockSize / 32;
-    const int numBlocks = min( 4096, (int) (A.get_num_rows() + numWarps - 1) / numWarps );
+    const int numBlocks = (int) (A.get_num_rows() + numWarps - 1) / numWarps;
 
     if (A.get_num_rows() > 0)
     {

--- a/core/src/core.cu
+++ b/core/src/core.cu
@@ -368,6 +368,7 @@ inline void registerParameters()
     AMG_Config::registerParameter<ViewType>("separation_interior", "separation for latency hiding and coloring/smoothing <ViewType>", INTERIOR, viewtype_values);
     AMG_Config::registerParameter<ViewType>("separation_exterior", "limit of calculations for coloring/smoothing <ViewType>", OWNED, viewtype_values);
     AMG_Config::registerParameter<int>("min_rows_latency_hiding", "number of rows at which to disable latency hiding, negative value means latency hiding is completely disabled", -1);
+    AMG_Config::registerParameter<int>("exact_coarse_solve", "flag that changes the dense LU coarse solve to solve the exact global problem for Classical AMG preconditioning <0=disable|1=enable>", 0, bool_flag_values);
     AMG_Config::registerParameter<int>("matrix_halo_exchange", "0 - No halo exchange on lower levels, 1 - just diagonal values, 2 - full", 0);
     std::vector<ColoringType> coloring_values;
     coloring_values.push_back(FIRST);

--- a/core/src/eigensolvers/qr.cu
+++ b/core/src/eigensolvers/qr.cu
@@ -338,7 +338,6 @@ vstack(Vector<TConfig> &dst, const Vector<TConfig> &top, const Vector<TConfig> &
     int height = top.get_num_rows();
     cudaMemcpy2D(dst.raw(), dpitch, top.raw(), spitch, width, height,
                  cudaMemcpyDeviceToDevice);
-    int offset = top.get_num_cols();
     cudaMemcpy2D(dst.raw() + top.get_num_cols(), dpitch, bottom.raw(), spitch, width, height,
                  cudaMemcpyDeviceToDevice);
 }


### PR DESCRIPTION
- Added cuSPARSE transpose
- Added all_gather_v implementation to comms
- Added L1 scaled norm calculation (to match OpenFOAM)
- Improved the calculation of multiple __shfl type operations to use double precision variants
- Optimised the block tuning for aggressive coarsening
- Fixed issue with view passing in matrix
- Improve handling of latency hiding in multiply
- Fixed some warnings with the compilation of CUDA 11.4... many outstanding
- Added an exact coarse solve accessible via flag exact_coarse_solve