### PR TITLE
Latency hiding fix for unbalanced decompositions

### DIFF
--- a/base/include/amg_level.h
+++ b/base/include/amg_level.h
@@ -218,7 +218,6 @@ class AMG_Level
         Matrix<TConfig> *A;
         Matrix<TConfig> *Aoriginal;
         VVector bc, xc, r;
-        int m_min_rows_latency_hiding;
 
         AMG_Class *amg;
         AMG_Level<TConfig_h> *next_h;

--- a/base/include/distributed/comms_mpi_hostbuffer_stream.h
+++ b/base/include/distributed/comms_mpi_hostbuffer_stream.h
@@ -501,8 +501,9 @@ class CommsMPIHostBufferStream : public CommsMPI<T_Config>
         void get_hostname(std::string &my_hostname);
         void exchange_hostnames(std::string &my_hostname, std::vector<std::string> &hostnames, int num_parts );
 
-        void all_gather(const IndexType_h &my_data, HIVector &gathered_data, int num_parts);
+        void all_gather(const int &my_data, HIVector &gathered_data, int num_parts);
         void all_gather(const int64_t &my_data, HI64Vector &gathered_data, int num_parts);
+
         void all_gather_v(HIVector &my_data, HIVector &gathered_data, int num_parts);
         void all_reduce_max(IndexType_h &my_data, IndexType_h &result_data);
 

--- a/base/include/distributed/comms_mpi_hostbuffer_stream.h
+++ b/base/include/distributed/comms_mpi_hostbuffer_stream.h
@@ -298,7 +298,7 @@ class CommsMPIHostBufferStream : public CommsMPI<T_Config>
         void recv_vec_wait_all(T &b);
 
         template <class T, class T2>
-        void all_gather_templated(T &my_data, T2 &gathered_data, int num_parts);
+        void all_gather_templated(const T &my_data, T2 &gathered_data, int num_parts);
 
         template <class T, class T2>
         void all_gather_v_templated(T &my_data, int num_elems, T2 &gathered_data, int num_parts);
@@ -501,7 +501,8 @@ class CommsMPIHostBufferStream : public CommsMPI<T_Config>
         void get_hostname(std::string &my_hostname);
         void exchange_hostnames(std::string &my_hostname, std::vector<std::string> &hostnames, int num_parts );
 
-        void all_gather(IndexType_h &my_data, HIVector &gathered_data, int num_parts);
+        void all_gather(const IndexType_h &my_data, HIVector &gathered_data, int num_parts);
+        void all_gather(const int64_t &my_data, HI64Vector &gathered_data, int num_parts);
         void all_gather_v(HIVector &my_data, HIVector &gathered_data, int num_parts);
         void all_reduce_max(IndexType_h &my_data, IndexType_h &result_data);
 

--- a/base/include/distributed/distributed_comms.h
+++ b/base/include/distributed/distributed_comms.h
@@ -333,7 +333,8 @@ class DistributedComms
         virtual void get_hostname(std::string &my_hostname) = 0;
         virtual void exchange_hostnames(std::string &my_hostname, std::vector<std::string> &hostnames, int num_parts ) = 0;
 
-        virtual void all_gather(IndexType_h &my_data, HIVector &gathered_data, int num_parts) = 0;
+        virtual void all_gather(const IndexType_h &my_data, HIVector &gathered_data, int num_parts) = 0;
+        virtual void all_gather(const int64_t &my_data, HI64Vector &gathered_data, int num_parts) = 0;
         virtual void all_gather_v(HIVector &my_data, HIVector &gathered_data, int num_parts) = 0;
 
         virtual void all_reduce_max(IndexType_h &my_data, IndexType_h &result_data) = 0;

--- a/base/include/matrix.h
+++ b/base/include/matrix.h
@@ -845,6 +845,8 @@ class MatrixBase : public AuxData, public Operator<T_Config>
         inline Resources *getResources() const { return m_resources; }
         inline void setResources(Resources *resources) { m_resources = resources; }
 
+        bool isLatencyHidingEnabled(AMG_Config& cfg);
+
         IVector m_larger_color_offsets; //size: num_rows
         IVector m_smaller_color_offsets; //size: num_rows,
         IVector m_values_permutation_vector;

--- a/base/src/amg_level.cu
+++ b/base/src/amg_level.cu
@@ -93,12 +93,11 @@ void AMG_Level<T_Config>::setup()
 
     if (separation_interior & INTERIOR == 0) { FatalError("Interior separation must include interior nodes", AMGX_ERR_CONFIGURATION); }
 
-    m_min_rows_latency_hiding = amg->m_cfg->AMG_Config::getParameter<int>("min_rows_latency_hiding", "default");
     this->getA().setExteriorView(separation_exterior);
     int offset, size;
     this->getA().getOffsetAndSizeForView(separation_exterior, &offset, &size);
 
-    if (m_min_rows_latency_hiding < 0 || size < m_min_rows_latency_hiding)
+    if (!this->getA().isLatencyHidingEnabled(*this->amg->m_cfg))
     {
         this->getA().setInteriorView(separation_exterior);
     }

--- a/base/src/distributed/comms_mpi_hostbuffer_stream.cu
+++ b/base/src/distributed/comms_mpi_hostbuffer_stream.cu
@@ -1516,7 +1516,10 @@ void CommsMPIHostBufferStream<T_Config>::exchange_hostnames(std::string &my_host
 }
 
 template <class T_Config>
-void CommsMPIHostBufferStream<T_Config>::all_gather(IndexType_h &my_data, HIVector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }
+void CommsMPIHostBufferStream<T_Config>::all_gather(const IndexType_h &my_data, HIVector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }
+
+template <class T_Config>
+void CommsMPIHostBufferStream<T_Config>::all_gather(const int64_t &my_data, HI64Vector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }
 
 template <class T_Config>
 void CommsMPIHostBufferStream<T_Config>::all_gather_v(HIVector &my_data, HIVector &gathered_data, int num_parts) { all_gather_v_templated(my_data[0], my_data.size(), gathered_data, num_parts); }
@@ -1534,7 +1537,7 @@ void CommsMPIHostBufferStream<T_Config>::all_reduce_max(IndexType_h &my_data, In
 
 template <class T_Config>
 template <class T, class T2>
-void CommsMPIHostBufferStream<T_Config>::all_gather_templated(T &my_data, T2 &gathered_data, int num_parts)
+void CommsMPIHostBufferStream<T_Config>::all_gather_templated(const T &my_data, T2 &gathered_data, int num_parts)
 {
 #ifdef AMGX_WITH_MPI
     gathered_data.resize(num_parts);

--- a/base/src/distributed/comms_mpi_hostbuffer_stream.cu
+++ b/base/src/distributed/comms_mpi_hostbuffer_stream.cu
@@ -1516,7 +1516,7 @@ void CommsMPIHostBufferStream<T_Config>::exchange_hostnames(std::string &my_host
 }
 
 template <class T_Config>
-void CommsMPIHostBufferStream<T_Config>::all_gather(const IndexType_h &my_data, HIVector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }
+void CommsMPIHostBufferStream<T_Config>::all_gather(const int &my_data, HIVector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }
 
 template <class T_Config>
 void CommsMPIHostBufferStream<T_Config>::all_gather(const int64_t &my_data, HI64Vector &gathered_data, int num_parts) { all_gather_templated(my_data, gathered_data, num_parts); }

--- a/base/src/distributed/distributed_io.cu
+++ b/base/src/distributed/distributed_io.cu
@@ -406,6 +406,7 @@ AMGX_ERROR DistributedRead<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_ind
     }
 
     remapReadColumns(A, partitionVec);
+
     return AMGX_OK;
 }
 

--- a/core/src/classical/classical_amg_level.cu
+++ b/core/src/classical/classical_amg_level.cu
@@ -455,7 +455,7 @@ void Classical_AMG_Level_Base<T_Config>::computeProlongationOperator()
         Truncate<TConfig>::truncateByMaxElements(P, this->max_elmts);
     }
 
-    if (this->m_min_rows_latency_hiding < 0 || P.get_num_rows() < this->m_min_rows_latency_hiding)
+    if (!P.isLatencyHidingEnabled(*this->amg->m_cfg))
     {
         // This will cause bsrmv_with_mask to not do latency hiding
         P.setInteriorView(OWNED);
@@ -477,7 +477,7 @@ void Classical_AMG_Level_Base<T_Config>::computeRestrictionOperator()
     P.setView(OWNED);
     transpose(P, R, P.get_num_rows());
 
-    if (this->m_min_rows_latency_hiding < 0 || R.get_num_rows() < this->m_min_rows_latency_hiding)
+    if (!R.isLatencyHidingEnabled(*this->amg->m_cfg))
     {
         // This will cause bsrmv_with_mask_restriction to not do latency hiding
         R.setInteriorView(OWNED);

--- a/core/src/energymin/energymin_amg_level.cu
+++ b/core/src/energymin/energymin_amg_level.cu
@@ -242,7 +242,7 @@ void Energymin_AMG_Level_Base<T_Config>
     R.setView(OWNED);
     transpose(R, P, R.get_num_rows());
 
-    if (this->m_min_rows_latency_hiding < 0 || P.get_num_rows() < this->m_min_rows_latency_hiding)
+    if (!P.isLatencyHidingEnabled(*this->amg->m_cfg))
     {
         // This will cause bsrmv to not do latency hiding
         P.setInteriorView(OWNED);


### PR DESCRIPTION
The latency hiding tests now check that all partitions have rows below the minimum threshold before disabling latency hiding.

This ensures that, if there are imbalances in the number of ranks, all partitions are following the same logical paths.