### PR TITLE
Fixed bug with the new SpGEMM fallback

### DIFF
--- a/base/src/csr_multiply.cu
+++ b/base/src/csr_multiply.cu
@@ -503,7 +503,6 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
     cusparseCheckError( cusparseDestroySpMat(matA) );
     cusparseCheckError( cusparseDestroySpMat(matB) );
     cusparseCheckError( cusparseDestroySpMat(matC) );
-    cusparseCheckError( cusparseDestroy(handle) );
     amgx::memory::cudaFreeAsync(dBuffer1);
     amgx::memory::cudaFreeAsync(dBuffer2);
 }


### PR DESCRIPTION
The singleton cuSPARSE handle was incorrectly destroyed which leads to handle errors in subsequent cuSPARSE calls if the fallback is encountered.