### PR TITLE
DRAFT: Replacing memory manager with cudaMallocAsync API

### DIFF
--- a/examples/amgx_mpi_capi_agg.c
+++ b/examples/amgx_mpi_capi_agg.c
@@ -447,11 +447,11 @@ int main(int argc, char **argv)
     if ((pidx = findParamIndex(argv, argc, "-gpu")) != -1)
     {
         /* allocate memory and copy the data to the GPU */
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_x, n * block_dimx * sizeof_v_val));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_b, n * block_dimy * sizeof_v_val));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_col_indices, nnz * sizeof(int)));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_row_ptrs, (n + 1)*sizeof(int)));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_values, nnz * block_size * sizeof_m_val));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_x, n * block_dimx * sizeof_v_val, 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_b, n * block_dimy * sizeof_v_val, 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_col_indices, nnz * sizeof(int), 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_row_ptrs, (n + 1)*sizeof(int), 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_values, nnz * block_size * sizeof_m_val, 0));
         CUDA_SAFE_CALL(cudaMemcpy(d_x, h_x, n * block_dimx * sizeof_v_val, cudaMemcpyDefault));
         CUDA_SAFE_CALL(cudaMemcpy(d_b, h_b, n * block_dimy * sizeof_v_val, cudaMemcpyDefault));
         CUDA_SAFE_CALL(cudaMemcpy(d_col_indices, h_col_indices, nnz * sizeof(int), cudaMemcpyDefault));
@@ -460,9 +460,10 @@ int main(int argc, char **argv)
 
         if (h_diag != NULL)
         {
-            CUDA_SAFE_CALL(cudaMalloc(&d_diag, n * block_size * sizeof_m_val));
+            CUDA_SAFE_CALL(cudaMallocAsync(&d_diag, n * block_size * sizeof_m_val, 0));
             CUDA_SAFE_CALL(cudaMemcpy(d_diag, h_diag, n * block_size * sizeof_m_val, cudaMemcpyDefault));
         }
+        cudaStreamSynchronize(0);
 
         /* set pointers to point to GPU (device) memory */
         row_ptrs = d_row_ptrs;
@@ -571,15 +572,15 @@ int main(int argc, char **argv)
     if ((pidx = findParamIndex(argv, argc, "-gpu")) != -1)
     {
         /* deallocate GPU (device) memory */
-        CUDA_SAFE_CALL(cudaFree(d_x));
-        CUDA_SAFE_CALL(cudaFree(d_b));
-        CUDA_SAFE_CALL(cudaFree(d_row_ptrs));
-        CUDA_SAFE_CALL(cudaFree(d_col_indices));
-        CUDA_SAFE_CALL(cudaFree(d_values));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_x, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_b, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_row_ptrs, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_col_indices, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_values, 0));
 
         if (d_diag != NULL)
         {
-            CUDA_SAFE_CALL(cudaFree(d_diag));
+            CUDA_SAFE_CALL(cudaFreeAsync(d_diag, 0));
         }
     }
     else

--- a/examples/amgx_mpi_capi_cla.c
+++ b/examples/amgx_mpi_capi_cla.c
@@ -439,11 +439,11 @@ int main(int argc, char **argv)
     if ((pidx = findParamIndex(argv, argc, "-gpu")) != -1)
     {
         /* allocate memory and copy the data to the GPU */
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_x, n * block_dimx * sizeof_v_val));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_b, n * block_dimy * sizeof_v_val));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_col_indices, nnz * sizeof(int64_t)));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_row_ptrs, (n + 1)*sizeof(int)));
-        CUDA_SAFE_CALL(cudaMalloc((void **)&d_values, nnz * block_size * sizeof_m_val));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_x, n * block_dimx * sizeof_v_val, 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_b, n * block_dimy * sizeof_v_val, 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_col_indices, nnz * sizeof(int64_t), 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_row_ptrs, (n + 1)*sizeof(int), 0));
+        CUDA_SAFE_CALL(cudaMallocAsync((void **)&d_values, nnz * block_size * sizeof_m_val, 0));
         CUDA_SAFE_CALL(cudaMemcpy(d_x, h_x, n * block_dimx * sizeof_v_val, cudaMemcpyDefault));
         CUDA_SAFE_CALL(cudaMemcpy(d_b, h_b, n * block_dimy * sizeof_v_val, cudaMemcpyDefault));
         CUDA_SAFE_CALL(cudaMemcpy(d_col_indices, h_col_indices, nnz * sizeof(int64_t), cudaMemcpyDefault));
@@ -452,9 +452,11 @@ int main(int argc, char **argv)
 
         if (h_diag != NULL)
         {
-            CUDA_SAFE_CALL(cudaMalloc(&d_diag, n * block_size * sizeof_m_val));
+            CUDA_SAFE_CALL(cudaMallocAsync(&d_diag, n * block_size * sizeof_m_val, 0));
             CUDA_SAFE_CALL(cudaMemcpy(d_diag, h_diag, n * block_size * sizeof_m_val, cudaMemcpyDefault));
         }
+
+        cudaStreamSynchronize(0);
 
         /* set pointers to point to GPU (device) memory */
         row_ptrs = d_row_ptrs;
@@ -592,15 +594,15 @@ int main(int argc, char **argv)
     if ((pidx = findParamIndex(argv, argc, "-gpu")) != -1)
     {
         /* deallocate GPU (device) memory */
-        CUDA_SAFE_CALL(cudaFree(d_x));
-        CUDA_SAFE_CALL(cudaFree(d_b));
-        CUDA_SAFE_CALL(cudaFree(d_row_ptrs));
-        CUDA_SAFE_CALL(cudaFree(d_col_indices));
-        CUDA_SAFE_CALL(cudaFree(d_values));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_x, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_b, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_row_ptrs, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_col_indices, 0));
+        CUDA_SAFE_CALL(cudaFreeAsync(d_values, 0));
 
         if (d_diag != NULL)
         {
-            CUDA_SAFE_CALL(cudaFree(d_diag));
+            CUDA_SAFE_CALL(cudaFreeAsync(d_diag, 0));
         }
     }
     else

--- a/include/cutil.h
+++ b/include/cutil.h
@@ -316,12 +316,13 @@ template <class ScalarType> bool containsNan( ScalarType *mem, int num )
 
     if (num > 0)
     {
-        cudaMalloc(&d_retval, sizeof(bool));
+        cudaMallocAsync(&d_retval, sizeof(bool), 0);
+        cudaStreamSynchronize(0);
         cudaMemcpy(d_retval, &retval, sizeof(bool), cudaMemcpyHostToDevice);
         containsNan_kernel <<< blocks, threads>>>(mem, num, d_retval);
         cudaCheckError();
         cudaMemcpy(&retval, d_retval, sizeof(bool), cudaMemcpyDeviceToHost);
-        cudaFree(d_retval);
+        cudaFreeAsync(d_retval, 0);
     }
 
     return retval;

--- a/include/energymin/interpolators/common.h
+++ b/include/energymin/interpolators/common.h
@@ -64,11 +64,12 @@ void allocMem(DataType *&ptr,
               IndexType numEntry,
               bool initToZero)
 {
-    if ( ptr != NULL ) { thrust::global_thread_handle::cudaFreeAsync(ptr); }
+    if ( ptr != NULL ) { cudaFreeAsync(ptr, 0); }
 
     cudaCheckError();
     size_t sz = numEntry * sizeof(DataType);
-    thrust::global_thread_handle::cudaMalloc((void **)&ptr, sz);
+    cudaMallocAsync((void **)&ptr, sz, 0);
+    cudaStreamSynchronize(0);
     cudaCheckError();
 
     if (initToZero)

--- a/include/global_thread_handle.h
+++ b/include/global_thread_handle.h
@@ -143,6 +143,8 @@ class MemoryPool
         //Mutex added to fix ICE threadsafe issue
         std::mutex m_mutex2;
 
+        cudaMemPool_t m_mem_pool;
+
     private:
         // No copy.
         MemoryPool(const MemoryPool &);

--- a/include/vector_thrust_allocator.h
+++ b/include/vector_thrust_allocator.h
@@ -120,7 +120,8 @@ class thrust_amgx_allocator
                                 const_pointer = const_pointer(static_cast<T *>(0)))
         {
             void *ptr;
-            amgx::memory::cudaMalloc(&ptr, sizeof(T)*cnt);
+            cudaMallocAsync(&ptr, sizeof(T)*cnt, 0);
+            cudaStreamSynchronize(0);
             return pointer((T *)ptr);
         } // end allocate()
 
@@ -133,7 +134,7 @@ class thrust_amgx_allocator
         __host__
         inline void deallocate(pointer p, size_type cnt)
         {
-            amgx::memory::cudaFreeAsync((void *)p.get());
+            cudaFreeAsync((void *)p.get(), 0);
         } // end deallocate()
 
         /*! Compares against another \p thrust_amgx_allocator for equality.

--- a/src/amgx_cusparse.cu
+++ b/src/amgx_cusparse.cu
@@ -1017,7 +1017,7 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
 
     if(col_off > 0)
     {
-        amgx::memory::cudaMalloc((void**)&rows, sizeof(IndType)*(mb+1));
+        cudaMallocAsync((void**)&rows, sizeof(IndType)*(mb+1), stream);
 
         constexpr int nthreads = 128;
         const int nblocks = (mb + 1) / nthreads + 1;
@@ -1039,7 +1039,7 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
     void* dBuffer = NULL;
     if(bufferSize > 0)
     {
-        amgx::memory::cudaMalloc(&dBuffer, bufferSize);
+        cudaMallocAsync(&dBuffer, bufferSize, stream);
     }
 
     cusparseCheckError(cusparseSpMV(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG2, dBuffer) );
@@ -1050,12 +1050,12 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
 
     if(bufferSize > 0)
     {
-        amgx::memory::cudaFreeAsync(dBuffer);
+        cudaFreeAsync(dBuffer, stream);
     }
 
     if(col_off > 0)
     {
-        amgx::memory::cudaFreeAsync(rows);
+        cudaFreeAsync(rows, stream);
     }
 }
 #endif
@@ -1577,7 +1577,7 @@ generic_SpMM(cusparseHandle_t handle, cusparseOperation_t transA,
     void* dBuffer = NULL;
     if(bufferSize > 0)
     {
-        amgx::memory::cudaMalloc(&dBuffer, bufferSize);
+        cudaMallocAsync(&dBuffer, bufferSize, 0);
     }
 
     // Compute the sparse matrix - dense matrix product
@@ -1592,7 +1592,7 @@ generic_SpMM(cusparseHandle_t handle, cusparseOperation_t transA,
 
     if(bufferSize > 0)
     {
-        amgx::memory::cudaFreeAsync(dBuffer);
+        cudaFreeAsync(dBuffer, 0);
     }
 }
 #endif
@@ -1731,7 +1731,7 @@ void transpose_internal(cusparseHandle_t handle, int nRows, int nCols, int nNz, 
     void *buffer = nullptr;
     if (bufferSize > 0)
     {
-        amgx::memory::cudaMalloc(&buffer, bufferSize);
+        cudaMallocAsync(&buffer, bufferSize, 0);
     }
 
     cusparseCheckError(cusparseCsr2cscEx2(
@@ -1740,7 +1740,7 @@ void transpose_internal(cusparseHandle_t handle, int nRows, int nCols, int nNz, 
 
     if(bufferSize > 0)
     {
-        amgx::memory::cudaFreeAsync(buffer);
+        cudaFreeAsync(buffer, 0);
     }
 }
 

--- a/src/amgx_lapack.cu
+++ b/src/amgx_lapack.cu
@@ -1014,7 +1014,7 @@ void gpu_geqrf(int m, int n, T *a, int lda,
 {
     int k = std::min(m, n);
     T *aii;
-    cudaMalloc(&aii, sizeof(T));
+    cudaMallocAsync(&aii, sizeof(T), 0);
 
     for (int i = 0; i < k; ++i)
     {
@@ -1040,7 +1040,7 @@ void gpu_geqrf(int m, int n, T *a, int lda,
         }
     }
 
-    cudaFree(aii);
+    cudaFreeAsync(aii, 0);
 }
 } // end anonymous namespace
 

--- a/src/csr_multiply.cu
+++ b/src/csr_multiply.cu
@@ -451,7 +451,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
                                   &alpha, matA, matB, &beta, matC,
                                   computeType, CUSPARSE_SPGEMM_DEFAULT,
                                   spgemmDesc, &bufferSize1, NULL);
-    amgx::memory::cudaMalloc(&dBuffer1, bufferSize1);
+    cudaMallocAsync(&dBuffer1, bufferSize1, 0);
     // inspect the matrices A and B to understand the memory requiremnent for
     // the next step
     cusparseSpGEMM_workEstimation(handle, opA, opB,
@@ -464,7 +464,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
                            &alpha, matA, matB, &beta, matC,
                            computeType, CUSPARSE_SPGEMM_DEFAULT,
                            spgemmDesc, &bufferSize2, NULL);
-    amgx::memory::cudaMalloc(&dBuffer2, bufferSize2);
+    cudaMallocAsync(&dBuffer2, bufferSize2, 0);
 
     // compute the intermediate product of A * B
     cusparseSpGEMM_compute(handle, opA, opB,
@@ -503,8 +503,8 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
     cusparseCheckError( cusparseDestroySpMat(matA) );
     cusparseCheckError( cusparseDestroySpMat(matB) );
     cusparseCheckError( cusparseDestroySpMat(matC) );
-    amgx::memory::cudaFreeAsync(dBuffer1);
-    amgx::memory::cudaFreeAsync(dBuffer2);
+    cudaFreeAsync(dBuffer1, 0);
+    cudaFreeAsync(dBuffer2, 0);
 }
 #endif
 
@@ -541,7 +541,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
             info, &pBufferSizeInBytes));
 
     // Allocate the intermediary buffer
-    amgx::memory::cudaMalloc(&pBuffer, pBufferSizeInBytes);
+    cudaMallocAsync(&pBuffer, pBufferSizeInBytes, 0);
 
     int nnzC;
     int *nnzTotalDevHostPtr = &nnzC;
@@ -596,7 +596,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
         cusparseSetPointerMode(handle, old_pointer_mode));
     cusparseCheckError(
         cusparseDestroyCsrgemm2Info(info));
-    amgx::memory::cudaFreeAsync(pBuffer);
+    cudaFreeAsync(pBuffer, 0);
 }
 #endif
 

--- a/src/distributed/distributed_manager.cu
+++ b/src/distributed/distributed_manager.cu
@@ -2033,7 +2033,7 @@ void *DistributedManagerBase<TConfig>::getDevicePointerForData(void *ptr, size_t
         if (rc != cudaSuccess)
         {
             //you are in case 1
-            rc = cudaMalloc(&ptr_d, size);
+            rc = cudaMallocAsync(&ptr_d, size, 0);
 
             if (rc != cudaSuccess)
             {
@@ -2121,7 +2121,7 @@ const void *DistributedManagerBase<TConfig>::getDevicePointerForData(const void 
         if (rc != cudaSuccess)
         {
             //you are in case 1
-            rc = cudaMalloc(&ptr_d, size);
+            rc = cudaMallocAsync(&ptr_d, size, 0);
 
             if (rc != cudaSuccess)
             {
@@ -4655,9 +4655,9 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     }
 
     /* free memory (if needed) */
-    if (col_alloc) { cudaFree(col_indices_hd); }
-    if (data_alloc) { cudaFree(data_hd); }
-    if (diag_alloc) { cudaFree(diag_hd); }
+    if (col_alloc) { cudaFreeAsync(col_indices_hd, 0); }
+    if (data_alloc) { cudaFreeAsync(data_hd, 0); }
+    if (diag_alloc) { cudaFreeAsync(diag_hd, 0); }
 }
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>
@@ -4716,8 +4716,8 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     cudaCheckError();
 
     /* free memory (if needed) */
-    if (data_alloc) { cudaFree(data_hd); }
-    if (diag_alloc) { cudaFree(diag_hd); }
+    if (data_alloc) { cudaFreeAsync(data_hd, 0); }
+    if (diag_alloc) { cudaFreeAsync(diag_hd, 0); }
 }
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>
@@ -4960,9 +4960,9 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     this->A->setView(OWNED);
 
     /* free memory (if needed) */
-    if (data_alloc) { cudaFree(data_hd); }
+    if (data_alloc) { cudaFreeAsync(data_hd, 0); }
 
-    if (diag_alloc) { cudaFree(diag_hd); }
+    if (diag_alloc) { cudaFreeAsync(diag_hd, 0); }
 }
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>
@@ -5172,7 +5172,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
     }
 
     /* free memory (if needed) */
-    if (data_alloc) { cudaFree(data_hd); }
+    if (data_alloc) { cudaFreeAsync(data_hd, 0); }
 
     cudaCheckError();
 }

--- a/src/energymin/interpolators/em.cu
+++ b/src/energymin/interpolators/em.cu
@@ -662,31 +662,31 @@ EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::
 
     if (m_dense_Aijs)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_dense_Aijs);
+        cudaFreeAsync(m_dense_Aijs, 0);
         m_dense_Aijs = 0;
     }
 
     if (m_dense_invAijs)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_dense_invAijs);
+        cudaFreeAsync(m_dense_invAijs, 0);
         m_dense_invAijs = 0;
     }
 
     if (m_ipiv)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_ipiv);
+        cudaFreeAsync(m_ipiv, 0);
         m_ipiv = 0;
     }
 
     if (m_cuds_wspace)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_cuds_wspace);
+        cudaFreeAsync(m_cuds_wspace, 0);
         m_cuds_wspace = 0;
     }
 
     if (m_cuds_info)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_cuds_info);
+        cudaFreeAsync(m_cuds_info, 0);
         m_cuds_info = 0;
     }
 }
@@ -1120,7 +1120,7 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
         cudaDeviceSynchronize();
     }
 
-    if (place_holder_ptr) { thrust::global_thread_handle::cudaFreeAsync(place_holder_ptr); place_holder_ptr = 0; }
+    if (place_holder_ptr) { cudaFreeAsync(place_holder_ptr, 0); place_holder_ptr = 0; }
 }
 
 
@@ -1199,7 +1199,7 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
     // Compute Ma matrix
     computeMa(Ma, AnumRows, numCoarse, P, m_dense_invAijs, AijOffsets, Ma_nzDiagRows);
 
-    if (m_dense_invAijs) { thrust::global_thread_handle::cudaFreeAsync(m_dense_invAijs);  m_dense_invAijs = 0; }
+    if (m_dense_invAijs) { cudaFreeAsync(m_dense_invAijs, 0);  m_dense_invAijs = 0; }
 
     /* At this point, we are done with the following Matlab code analogue.
     for (int j=1; j<=nc; j++)
@@ -1238,13 +1238,13 @@ void EM_Interpolator<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec
     // Compute the values of P
     computePvalues( AnumRows, numCoarse, P, v_x, m_dense_Aijs, AijOffsets, m_ipiv, m_cuds_handle, m_cuds_info );
 
-    if (m_dense_Aijs) { thrust::global_thread_handle::cudaFreeAsync(m_dense_Aijs);  m_dense_Aijs = 0; }
+    if (m_dense_Aijs) { cudaFreeAsync(m_dense_Aijs, 0);  m_dense_Aijs = 0; }
 
-    if (m_ipiv)       { thrust::global_thread_handle::cudaFreeAsync(m_ipiv);        m_ipiv = 0; }
+    if (m_ipiv)       { cudaFreeAsync(m_ipiv, 0);        m_ipiv = 0; }
 
-    if (m_cuds_info)  { thrust::global_thread_handle::cudaFreeAsync(m_cuds_info);   m_cuds_info = 0; }
+    if (m_cuds_info)  { cudaFreeAsync(m_cuds_info, 0);   m_cuds_info = 0; }
 
-    //if (m_dense_invAijs) { thrust::global_thread_handle::cudaFreeAsync(m_dense_invAijs);  m_dense_invAijs = 0; }
+    //if (m_dense_invAijs) { cudaFreeAsync(m_dense_invAijs, 0);  m_dense_invAijs = 0; }
     /* Now, we are done building columns of P (stored as rows of P^T in CSR).
      * Here's the equivalent matlab code.
     P = zeros(n,nc);

--- a/src/global_thread_handle.cu
+++ b/src/global_thread_handle.cu
@@ -82,6 +82,11 @@ MemoryPool::MemoryPool(size_t max_block_size, size_t page_size, size_t max_size)
     , m_recently_merged(false)
 {
     //initializeCriticalSection(&m_mutex2);
+    int device;
+    cudaGetDevice(&device);
+    cudaDeviceGetMemPool(&m_mem_pool, device);
+    uint64_t max_threshold = std::numeric_limits<uint64_t>::max();
+    cudaMemPoolSetAttribute(m_mem_pool, cudaMemPoolAttrReleaseThreshold, &max_threshold);
 }
 
 MemoryPool::~MemoryPool()

--- a/src/global_thread_handle.cu
+++ b/src/global_thread_handle.cu
@@ -400,7 +400,7 @@ DeviceMemoryPool::DeviceMemoryPool(size_t size,
     }
 
     void *ptr = NULL;
-    ::cudaMalloc(&ptr, size);
+    ::cudaMallocAsync(&ptr, size, 0);
 
     if ( ptr == NULL )
     {
@@ -419,7 +419,7 @@ void DeviceMemoryPool::expandPool(size_t size,
     }
 
     void *ptr = NULL;
-    ::cudaMalloc(&ptr, size);
+    ::cudaMallocAsync(&ptr, size, 0);
 
     if ( ptr == NULL )
     {
@@ -435,7 +435,7 @@ DeviceMemoryPool::~DeviceMemoryPool()
     for ( size_t i = 0 ; i < m_owned_ptrs.size() ; ++i )
         if (m_owned_ptrs[i].m_managed)
         {
-            ::cudaFree(m_owned_ptrs[i].m_begin);
+            ::cudaFreeAsync(m_owned_ptrs[i].m_begin, 0);
         }
 
     m_owned_ptrs.clear();
@@ -889,7 +889,7 @@ cudaError_t cudaMalloc(void **ptr, size_t size)
         allocated_size = manager.scale(size);
         // We hack the size to make it a multiple of a page size.
         allocated_size = PAGE_SIZE * ((allocated_size + PAGE_SIZE - 1) / PAGE_SIZE);
-        error = ::cudaMalloc(ptr, allocated_size);
+        error = ::cudaMallocAsync(ptr, allocated_size, 0);
 
         // Very last attempt. Try without over allocation.
         if ( *ptr == NULL )
@@ -1017,7 +1017,7 @@ cudaError_t cudaFreeAsync(void *ptr)
 #ifdef AMGX_PRINT_MEMORY_INFO
         print_fallback = true;
 #endif
-        status = ::cudaFree(ptr);
+        status = ::cudaFreeAsync(ptr, 0);
     }
 
 #ifdef AMGX_PRINT_MEMORY_INFO

--- a/src/hash_workspace.cu
+++ b/src/hash_workspace.cu
@@ -46,8 +46,8 @@ Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::Hash_Workspace(
     m_keys(NULL),
     m_vals(NULL)
 {
-    thrust::global_thread_handle::cudaMalloc( (void **) &m_status, sizeof(int) );
-    thrust::global_thread_handle::cudaMalloc( (void **) &m_work_queue, sizeof(int) );
+    cudaMallocAsync( (void **) &m_status, sizeof(int), 0 );
+    cudaMallocAsync( (void **) &m_work_queue, sizeof(int), 0 );
     allocate_workspace();
 }
 
@@ -58,12 +58,12 @@ Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::~Hash_Workspace
 {
     if ( m_allocate_vals )
     {
-        thrust::global_thread_handle::cudaFreeAsync( m_vals );
+        cudaFreeAsync( m_vals, 0 );
     }
 
-    thrust::global_thread_handle::cudaFreeAsync( m_keys );
-    thrust::global_thread_handle::cudaFreeAsync( m_work_queue );
-    thrust::global_thread_handle::cudaFreeAsync( m_status );
+    cudaFreeAsync( m_keys, 0 );
+    cudaFreeAsync( m_work_queue, 0 );
+    cudaFreeAsync( m_status, 0 );
 }
 
 // ====================================================================================================================
@@ -76,11 +76,11 @@ void Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::allocate_w
     // Allocate memory to store the keys of the device-based hashtable.
     if ( m_keys != NULL )
     {
-        thrust::global_thread_handle::cudaFreeAsync( m_keys );
+        cudaFreeAsync( m_keys, 0 );
     }
 
     size_t sz = NUM_WARPS_IN_GRID * m_gmem_size * sizeof(Key_type);
-    thrust::global_thread_handle::cudaMalloc( (void **) &m_keys, sz );
+    cudaMallocAsync( (void **) &m_keys, sz, 0 );
 
     // Skip value allocation if needed.
     if ( !m_allocate_vals )
@@ -91,11 +91,11 @@ void Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::allocate_w
     // Allocate memory to store the values of the device-based hashtable.
     if ( m_vals != NULL )
     {
-        thrust::global_thread_handle::cudaFreeAsync( m_vals );
+        cudaFreeAsync( m_vals, 0 );
     }
 
     sz = NUM_WARPS_IN_GRID * m_gmem_size * sizeof(double);
-    thrust::global_thread_handle::cudaMalloc( (void **) &m_vals, sz );
+    cudaMallocAsync( (void **) &m_vals, sz, 0 );
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scalers/diagonal_symmetric.cu
+++ b/src/scalers/diagonal_symmetric.cu
@@ -138,7 +138,7 @@ void DiagonalSymmetricScaler<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t
     grabDiagonalVector <<< 4096, 128>>>(A.get_num_rows(), A.row_offsets.raw(), A.col_indices.raw(), A.values.raw(), diag.raw());
     // check diagonal +ve
     bool positive = true, *d_positive;
-    cudaMalloc(&d_positive, sizeof(bool));
+    cudaMallocAsync(&d_positive, sizeof(bool), 0);
     cudaMemcpy(d_positive, &positive, sizeof(bool), cudaMemcpyHostToDevice);
     checkPositiveVector <<< 4096, 256>>>(diag.size(), diag.raw(), d_positive);
     cudaMemcpy(&positive, d_positive, sizeof(bool), cudaMemcpyDeviceToHost);

--- a/src/solvers/dense_lu_solver.cu
+++ b/src/solvers/dense_lu_solver.cu
@@ -588,7 +588,7 @@ void DenseLUSolver<TemplateConfig<AMGX_device, V, M, I> >::cudense_getrf()
 
     if (m_trf_wspace)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_trf_wspace);
+        cudaFreeAsync(m_trf_wspace, 0);
         m_trf_wspace = 0;
     }
 }
@@ -626,11 +626,11 @@ allocMem(DataType *&ptr,
          IndexType numEntry,
          bool initToZero)
 {
-    if ( ptr != NULL ) { thrust::global_thread_handle::cudaFreeAsync(ptr); }
+    if ( ptr != NULL ) { cudaFreeAsync(ptr, 0); }
 
     cudaCheckError();
     size_t sz = numEntry * sizeof(DataType);
-    thrust::global_thread_handle::cudaMalloc((void **)&ptr, sz);
+    cudaMallocAsync((void **)&ptr, sz, 0);
     cudaCheckError();
 
     if (initToZero)
@@ -702,22 +702,22 @@ DenseLUSolver<TemplateConfig<AMGX_device, V, M, I> >::~DenseLUSolver()
 
     if (m_dense_A)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_dense_A);
+        cudaFreeAsync(m_dense_A, 0);
     }
 
     if (m_ipiv)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_ipiv);
+        cudaFreeAsync(m_ipiv, 0);
     }
 
     if (m_trf_wspace)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_trf_wspace);
+        cudaFreeAsync(m_trf_wspace, 0);
     }
 
     if (m_cuds_info)
     {
-        thrust::global_thread_handle::cudaFreeAsync(m_cuds_info);
+        cudaFreeAsync(m_cuds_info, 0);
     }
 
     cudaCheckError();

--- a/src/tests/dense_lu.cu
+++ b/src/tests/dense_lu.cu
@@ -111,9 +111,9 @@ template< typename Matrix_data >
 void l_times_u(int n, Matrix_data *lu_d, int lda)
 {
     Matrix_data *l_d, *u_d;
-    cudaMalloc((void **) &l_d, n * lda * sizeof(Matrix_data));
+    cudaMallocAsync((void **) &l_d, n * lda * sizeof(Matrix_data), 0);
     UNITTEST_ASSERT_EQUAL(cudaGetLastError(), cudaSuccess);
-    cudaMalloc((void **) &u_d, n * lda * sizeof(Matrix_data));
+    cudaMallocAsync((void **) &u_d, n * lda * sizeof(Matrix_data), 0);
     UNITTEST_ASSERT_EQUAL(cudaGetLastError(), cudaSuccess);
     // Split LU.
     dim3 block_dim(16, 16);
@@ -137,9 +137,9 @@ void l_times_u(int n, Matrix_data *lu_d, int lda)
     UNITTEST_ASSERT_EQUAL(cublas_status, CUBLAS_STATUS_SUCCESS);
     cublas_status = cublasDestroy(cublas_handle);
     UNITTEST_ASSERT_EQUAL(cublas_status, CUBLAS_STATUS_SUCCESS);
-    cudaFree(l_d);
+    cudaFreeAsync(l_d, 0);
     UNITTEST_ASSERT_EQUAL(cudaGetLastError(), cudaSuccess);
-    cudaFree(u_d);
+    cudaFreeAsync(u_d, 0);
     UNITTEST_ASSERT_EQUAL(cudaGetLastError(), cudaSuccess);
 }
 


### PR DESCRIPTION
Currently proof of concept demonstrating that cudaMallocAsync can match performance of the existing custom memory allocator. This requires the threshold of the memory pool to be set (currently maxing out to ensure all allocations persist).

Planning to make it so default memory pool is used unless user provides a custom memory pool.