### PR TITLE
Remove static lib and remove bsrmv getFixedSizesForView

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ ENDIF()
 
 add_dependencies(amgx_tests_launcher amgx_tests_library)
 
-target_link_libraries(amgx_tests_launcher amgxsh amgx ${libs_all} OpenMP::OpenMP_C)
+target_link_libraries(amgx_tests_launcher amgxsh ${libs_all} OpenMP::OpenMP_C)
 
 if(MPI_FOUND)
     target_link_libraries(amgx_tests_launcher MPI::MPI_CXX)

--- a/src/amgx_cusparse.cu
+++ b/src/amgx_cusparse.cu
@@ -654,7 +654,8 @@ void Cusparse::bsrmv_internal_with_mask( const typename TConfig::VecPrec alphaCo
     typedef typename Matrix<TConfig>::index_type index_type;
 
     int offset, nrows, nnz;
-    A.getFixedSizesForView(view, &offset, &nrows, &nnz);
+    A.getOffsetAndSizeForView(view, &offset, &nrows);
+    A.getNnzForView(view, &nnz);
 
     if (nrows <= 0)
     {


### PR DESCRIPTION
Removed static lib from amgx_tests_launch and fixed issue where one of the bsrmv routines was using getFixedSizesForView.