### PR TITLE
Replaced uses of __syncwarp with utils::syncwarp.

### DIFF
--- a/include/hash_containers_sm70.inl
+++ b/include/hash_containers_sm70.inl
@@ -103,7 +103,7 @@ void Hash_set<Key_type, SMEM_SIZE, NUM_HASH_FCTS, WARP_SIZE>::clear( bool skip_g
     {
         m_smem_keys[i_step * WARP_SIZE + lane_id] = -1;
     }
-    __syncwarp();
+    utils::syncwarp();
 
     m_smem_count = 0;
 
@@ -674,7 +674,7 @@ void Hash_map<Key_type, T, SMEM_SIZE, NUM_HASH_FCTS, WARP_SIZE>::clear()
         m_smem_keys[i_step * WARP_SIZE + lane_id] = -1;
         m_smem_vals[i_step * WARP_SIZE + lane_id] =  amgx::types::util<T>::get_zero();
     }
-    __syncwarp();
+    utils::syncwarp();
 
     if ( !m_any_gmem )
     {
@@ -802,7 +802,7 @@ void Hash_map<Key_type, T, SMEM_SIZE, NUM_HASH_FCTS, WARP_SIZE>::load( int count
         ptr[idx] = key;
     }
 
-    __syncwarp();
+    utils::syncwarp();
 
     m_any_gmem = utils::any( m_any_gmem );
 }

--- a/src/classical/interpolators/distance2.cu
+++ b/src/classical/interpolators/distance2.cu
@@ -838,7 +838,7 @@ estimate_c_hat_size_kernel( const int A_num_rows,
                 s_b_row_ids[warp_id * WARP_SIZE + dest] = a_col_id;
             }
 
-            __syncwarp();
+            utils::syncwarp();
 
             // For each warp, we have up to 32 rows of B to proceed.
 
@@ -1003,7 +1003,7 @@ compute_c_hat_kernel( int A_num_rows,
                 s_b_row_ids[warp_id * WARP_SIZE + dest] = a_col_id;
             }
 
-            __syncwarp();
+            utils::syncwarp();
 
             int num_rows = __popc( vote );
 
@@ -1169,7 +1169,7 @@ compute_c_hat_kernel( int A_num_rows,
                 s_b_row_ids[warp_id * WARP_SIZE + dest] = a_col_id;
             }
 
-            __syncwarp();
+            utils::syncwarp();
 
             int num_rows = __popc( vote );
 
@@ -1355,7 +1355,7 @@ compute_inner_sum_kernel( const int A_num_rows,
                 s_a_values [warp_id * WARP_SIZE + dest] = a_value;
             }
 
-            __syncwarp();
+            utils::syncwarp();
 
             int num_rows = __popc( vote );
             // First n_rows threads reload the correct value.
@@ -1784,7 +1784,7 @@ compute_interp_weight_kernel( const int A_num_rows,
                 s_b_row_ids[warp_id * WARP_SIZE + dest] = a_col_id;
             }
 
-            __syncwarp();
+            utils::syncwarp();
 
             int num_rows = __popc( vote );
             // We pre-load inner sums.
@@ -1814,7 +1814,7 @@ compute_interp_weight_kernel( const int A_num_rows,
                     s_aki[warp_id] = Value_type(0);
                 }
 
-                __syncwarp();
+                utils::syncwarp();
 
                 // Load the kth inner sum.
                 Value_type uniform_val = utils::shfl( sum, k );
@@ -1848,7 +1848,7 @@ compute_interp_weight_kernel( const int A_num_rows,
                     map.update( b_col_id, b_value * uniform_val );
                 }
 
-                __syncwarp();
+                utils::syncwarp();
 
                 // The thread k updates the sum.
                 if ( lane_id == 0 )

--- a/src/classical/strength/strength_base.cu
+++ b/src/classical/strength/strength_base.cu
@@ -234,7 +234,7 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
             s_diag[warpId] = ValueType(0);
         }
 
-        __syncwarp();
+        utils::syncwarp();
 
         // Row sum
         ValueType rowSum = -1.0;
@@ -278,7 +278,7 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
             }
         }
 
-        __syncwarp();
+        utils::syncwarp();
 
         // Big assumption: diag and off-diag always have the opposite sign.
         // If diag entry is negative, then all off-diag entries must be positive.
@@ -288,7 +288,7 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
         {
             smem[threadIdx.x] = maxVal;
 
-            __syncwarp();
+            utils::syncwarp();
 
 #pragma unroll
             for ( int offset = 16 ; offset > 0 ; offset /= 2 )
@@ -297,14 +297,14 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
                 {
                     smem[threadIdx.x] = maxVal = max( maxVal, smem[threadIdx.x + offset] );
                 }
-                __syncwarp();
+                utils::syncwarp();
             }
         }
         else
         {
             smem[threadIdx.x] = minVal;
 
-            __syncwarp();
+            utils::syncwarp();
 
 #pragma unroll
             for ( int offset = 16 ; offset > 0 ; offset /= 2 )
@@ -313,7 +313,7 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
                 {
                     smem[threadIdx.x] = minVal = min( minVal, smem[threadIdx.x + offset] );
                 }
-                __syncwarp();
+                utils::syncwarp();
             }
         }
 
@@ -323,7 +323,7 @@ void computeStrongConnectionsAndWeightsKernel( const IndexType *A_rows,
             s_threshold[warpId] = smem[threadIdx.x] * alpha;
         }
 
-        __syncwarp();
+        utils::syncwarp();
 
         // sum of the column of S
         for ( IndexType aRowIt = aRowBegin + laneId ; utils::any( aRowIt < aRowEnd ) ;


### PR DESCRIPTION
For consistency, changing all calls to __syncwarp to instead use utils::syncwarp.