### PR TITLE
Removed cases of using namespace std

### DIFF
--- a/include/amgx_timer.h
+++ b/include/amgx_timer.h
@@ -68,13 +68,8 @@ public:
 /**********************************************
  *  class for holding profiling data if desired
  *********************************************/
-using namespace std::chrono;
-using std::cout;
-using std::endl;
-using std::setw;
-
 typedef std::map<const char *, double> Times;
-typedef std::map<const char *, high_resolution_clock::time_point> Event;
+typedef std::map<const char *, std::chrono::high_resolution_clock::time_point> Event;
 
 class levelProfile
 {
@@ -100,7 +95,7 @@ class levelProfile
         {
 #ifdef PROFILE
             cudaDeviceSynchronize();
-            duration<double, std::nano> ns = t2 - t1;
+            std::chrono::duration<double, std::nano> ns = t2 - t1;
             times[event] += ns.count();
 #endif
         }
@@ -245,7 +240,7 @@ class Profiler_entry
 
         inline void stop()
         {
-            m_time = std::max( 0ull, (duration_cast<nanoseconds>(t2 - t1)).count());
+            m_time = std::max( 0ull, (std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1)).count());
         }
 };
 
@@ -318,7 +313,7 @@ class Timer
 
 class TimerCPU : public Timer
 {
-        high_resolution_clock::time_point  m_last_tick;
+    std::chrono::high_resolution_clock::time_point  m_last_tick;
         bool    m_is_running;
     public:
         TimerCPU(bool accumulate_average): Timer(accumulate_average), m_is_running(false) {};
@@ -331,7 +326,7 @@ class TimerCPU : public Timer
         {
             if (!m_is_running)
             {
-                m_last_tick = high_resolution_clock::now();
+                m_last_tick = std::chrono::high_resolution_clock::now();
                 m_is_running = true;
             }
         }
@@ -342,8 +337,8 @@ class TimerCPU : public Timer
 
             if (m_is_running)
             {
-                duration<double> dsec = high_resolution_clock::now() - m_last_tick;
-                res = (duration_cast<nanoseconds>(dsec)).count();
+                std::chrono::duration<double> dsec = std::chrono::high_resolution_clock::now() - m_last_tick;
+                res = (std::chrono::duration_cast<std::chrono::nanoseconds>(dsec)).count();
                 m_is_running = false;
                 m_counter ++;
             }
@@ -358,8 +353,8 @@ class TimerCPU : public Timer
 
             if (m_is_running)
             {
-                duration<double> dsec = high_resolution_clock::now() - m_last_tick;
-                res = (duration_cast<nanoseconds>(dsec)).count();
+                std::chrono::duration<double> dsec = std::chrono::high_resolution_clock::now() - m_last_tick;
+                res = (std::chrono::duration_cast<std::chrono::nanoseconds>(dsec)).count();
             }
 
             return res;

--- a/include/matrix_coloring/locally_downwind.h
+++ b/include/matrix_coloring/locally_downwind.h
@@ -30,8 +30,6 @@
 #include <matrix_coloring/matrix_coloring.h>
 #include <basic_types.h>
 
-using namespace std;
-
 namespace amgx
 {
 

--- a/include/matrix_coloring/min_max.h
+++ b/include/matrix_coloring/min_max.h
@@ -31,7 +31,6 @@
 #include <basic_types.h>
 #include <matrix.h>
 #include <profile.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/matrix_coloring/multi_hash.h
+++ b/include/matrix_coloring/multi_hash.h
@@ -30,7 +30,6 @@
 #include <matrix_coloring/matrix_coloring.h>
 #include <basic_types.h>
 #include <profile.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/matrix_coloring/round_robin.h
+++ b/include/matrix_coloring/round_robin.h
@@ -30,8 +30,6 @@
 #include <matrix_coloring/matrix_coloring.h>
 #include <basic_types.h>
 
-using namespace std;
-
 namespace amgx
 {
 

--- a/include/matrix_coloring/uniform.h
+++ b/include/matrix_coloring/uniform.h
@@ -31,7 +31,6 @@
 #include <basic_types.h>
 #include <matrix.h>
 #include <profile.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/readers.h
+++ b/include/readers.h
@@ -34,8 +34,6 @@
 #include <amg_config.h>
 #include <matrix_io.h>
 
-using namespace std;
-
 namespace amgx
 {
 

--- a/include/scalers/scaler.h
+++ b/include/scalers/scaler.h
@@ -36,8 +36,6 @@
 namespace amgx
 {
 
-using namespace std;
-
 template <class T_config> class Scaler;
 
 enum ScaleDirection {SCALE, UNSCALE};

--- a/include/solvers/block_jacobi_solver.h
+++ b/include/solvers/block_jacobi_solver.h
@@ -29,7 +29,6 @@
 
 #include <solvers/solver.h>
 #include <amgx_types/util.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/solvers/cf_jacobi_solver.h
+++ b/include/solvers/cf_jacobi_solver.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include<solvers/solver.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/solvers/chebyshev_poly.h
+++ b/include/solvers/chebyshev_poly.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include <solvers/solver.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/solvers/fixcolor_gauss_seidel_solver.h
+++ b/include/solvers/fixcolor_gauss_seidel_solver.h
@@ -33,8 +33,6 @@
 #include <basic_types.h>
 #include <matrix.h>
 
-using namespace std;
-
 namespace amgx
 {
 namespace fixcolor_gauss_seidel_solver

--- a/include/solvers/kaczmarz_solver.h
+++ b/include/solvers/kaczmarz_solver.h
@@ -28,7 +28,6 @@
 #pragma once
 
 #include<solvers/solver.h>
-using namespace std;
 
 namespace amgx
 {

--- a/include/solvers/multicolor_dilu_solver.h
+++ b/include/solvers/multicolor_dilu_solver.h
@@ -35,8 +35,6 @@
 
 #include <amgx_types/util.h>
 
-using namespace std;
-
 namespace amgx
 {
 namespace multicolor_dilu_solver

--- a/include/solvers/multicolor_gauss_seidel_solver.h
+++ b/include/solvers/multicolor_gauss_seidel_solver.h
@@ -32,8 +32,6 @@
 #include <basic_types.h>
 #include <matrix.h>
 
-using namespace std;
-
 namespace amgx
 {
 namespace multicolor_gauss_seidel_solver

--- a/include/solvers/multicolor_ilu_solver.h
+++ b/include/solvers/multicolor_ilu_solver.h
@@ -32,8 +32,6 @@
 #include <basic_types.h>
 #include <matrix.h>
 
-using namespace std;
-
 namespace amgx
 {
 namespace multicolor_ilu_solver

--- a/src/aggregation/coarseAgenerators/coarse_A_generator.cu
+++ b/src/aggregation/coarseAgenerators/coarse_A_generator.cu
@@ -42,7 +42,6 @@ namespace amgx
 
 namespace aggregation
 {
-using namespace std;
 
 // ---------------------------------------------------------------------
 // Method to print the distribution of number of nonzeros in matrix Ac
@@ -75,14 +74,14 @@ CoarseAGeneratorFactory<T_Config>::getFactories( )
 }
 
 template<class T_Config>
-void CoarseAGeneratorFactory<T_Config>::registerFactory(string name, CoarseAGeneratorFactory<T_Config> *f)
+void CoarseAGeneratorFactory<T_Config>::registerFactory(std::string name, CoarseAGeneratorFactory<T_Config> *f)
 {
     std::map<std::string, CoarseAGeneratorFactory<T_Config>*> &factories = getFactories( );
-    typename map<string, CoarseAGeneratorFactory<T_Config> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, CoarseAGeneratorFactory<T_Config> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "CoarseAGeneratorFactory '" + name + "' has already been registered\n";
+        std::string error = "CoarseAGeneratorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -93,11 +92,11 @@ template<class T_Config>
 void CoarseAGeneratorFactory<T_Config>::unregisterFactory(std::string name)
 {
     std::map<std::string, CoarseAGeneratorFactory<T_Config>*> &factories = getFactories( );
-    typename map<string, CoarseAGeneratorFactory<T_Config> *>::iterator it = factories.find(name);
+    typename std::map<std::string, CoarseAGeneratorFactory<T_Config> *>::iterator it = factories.find(name);
 
     if (it == factories.end())
     {
-        string error = "CoarseAGeneratorFactory '" + name + "' has not been registered\n";
+        std::string error = "CoarseAGeneratorFactory '" + name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -111,7 +110,7 @@ template<class T_Config>
 void CoarseAGeneratorFactory<T_Config>::unregisterFactories( )
 {
     std::map<std::string, CoarseAGeneratorFactory<T_Config>*> &factories = getFactories( );
-    typename map<std::string, CoarseAGeneratorFactory<T_Config> *>::iterator it = factories.begin( );
+    typename std::map<std::string, CoarseAGeneratorFactory<T_Config> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -129,13 +128,13 @@ CoarseAGenerator<T_Config> *CoarseAGeneratorFactory<T_Config>::allocate(AMG_Conf
 {
     std::map<std::string, CoarseAGeneratorFactory<T_Config>*> &factories = getFactories( );
     int agg_lvl_change = cfg.AMG_Config::getParameter<int>("fine_levels", cfg_scope);
-    string generator;
-    generator = cfg.getParameter<string>("coarseAgenerator", cfg_scope);
-    typename map<string, CoarseAGeneratorFactory<T_Config> *>::const_iterator it = factories.find(generator);
+    std::string generator;
+    generator = cfg.getParameter<std::string>("coarseAgenerator", cfg_scope);
+    typename std::map<std::string, CoarseAGeneratorFactory<T_Config> *>::const_iterator it = factories.find(generator);
 
     if (it == factories.end())
     {
-        string error = "CoarseAGeneratorFactory '" + generator + "' has not been registered\n";
+        std::string error = "CoarseAGeneratorFactory '" + generator + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/aggregation/selectors/agg_selector.cu
+++ b/src/aggregation/selectors/agg_selector.cu
@@ -36,7 +36,6 @@
 namespace amgx
 {
 
-using namespace std;
 namespace aggregation
 {
 
@@ -239,14 +238,14 @@ SelectorFactory<T_Config>::getFactories( )
 }
 
 template<class T_Config>
-void SelectorFactory<T_Config>::registerFactory(string name, SelectorFactory<T_Config> *f)
+void SelectorFactory<T_Config>::registerFactory(std::string name, SelectorFactory<T_Config> *f)
 {
     std::map<std::string, SelectorFactory<T_Config>*> &factories = getFactories( );
-    typename map<string, SelectorFactory<T_Config> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, SelectorFactory<T_Config> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "SelectorFactory '" + name + "' has already been registered\n";
+        std::string error = "SelectorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -275,7 +274,7 @@ template<class T_Config>
 void SelectorFactory<T_Config>::unregisterFactories( )
 {
     std::map<std::string, SelectorFactory<T_Config>*> &factories = getFactories( );
-    typename map<std::string, SelectorFactory<T_Config> *>::iterator it = factories.begin( );
+    typename std::map<std::string, SelectorFactory<T_Config> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -294,12 +293,12 @@ Selector<T_Config> *SelectorFactory<T_Config>::allocate(AMG_Config &cfg, const s
     std::map<std::string, SelectorFactory<T_Config>*> &factories = getFactories( );
     int agg_lvl_change = cfg.AMG_Config::getParameter<int>("fine_levels", current_scope);
     std::string selector;
-    selector = cfg.getParameter<string>("selector", current_scope);
-    typename map<string, SelectorFactory<T_Config> *>::const_iterator it = factories.find(selector);
+    selector = cfg.getParameter<std::string>("selector", current_scope);
+    typename std::map<std::string, SelectorFactory<T_Config> *>::const_iterator it = factories.find(selector);
 
     if (it == factories.end())
     {
-        string error = "SelectorFactory '" + selector + "' has not been registered\n";
+        std::string error = "SelectorFactory '" + selector + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/amg.cu
+++ b/src/amg.cu
@@ -1257,7 +1257,7 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::getGridStatisticsString(std::stringst
     int64_t total_nnz = 0;
     float total_size = 0;
     ss << "AMG Grid:\n";
-    ss << "         Number of Levels: " << this->num_levels << endl;
+    ss << "         Number of Levels: " << this->num_levels << std::endl;
     ss << std::setw(15) << "LVL" << std::setw(13) << "ROWS" << std::setw(18) << "NNZ"
        << std::setw(10) << "SPRSTY" << std::setw(15) << "Mem (GB)" << std::endl;
     ss << "         --------------------------------------------------------------\n";
@@ -1421,14 +1421,14 @@ using std::fixed;
 void printLine(const int l, const int s)
 {
     std::stringstream ss;
-    ss << setw(s) << " ";
+    ss << std::setw(s) << " ";
 
     for (int i = 0; i < l; i++)
     {
         ss << "-";
     }
 
-    ss << endl;
+    ss << std::endl;
     amgx_output(ss.str().c_str(), static_cast<int>(ss.str().length()));
 }
 
@@ -1452,11 +1452,11 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printCoarsePoints()
             break;
         }
 
-        coarsePoints << level_d->level_id << " " << level_d->getNumRows() << endl;
+        coarsePoints << level_d->level_id << " " << level_d->getNumRows() << std::endl;
 
         for (iVecIter it = originalRows.begin(); it != originalRows.end(); ++it)
         {
-            coarsePoints << *it << endl;
+            coarsePoints << *it << std::endl;
         }
     }
 
@@ -1472,11 +1472,11 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printCoarsePoints()
             break;
         }
 
-        coarsePoints << level_h->level_id << " " << level_h->getNumRows() << endl;
+        coarsePoints << level_h->level_id << " " << level_h->getNumRows() << std::endl;
 
         for (iVecIter it = originalRows.begin(); it != originalRows.end(); ++it)
         {
-            coarsePoints << *it << endl;
+            coarsePoints << *it << std::endl;
         }
     }
 
@@ -1494,7 +1494,7 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printConnections()
 
     while (level_d != NULL)
     {
-        connFile << level_d->level_id << " " << level_d->getNumRows() << endl;
+        connFile << level_d->level_id << " " << level_d->getNumRows() << std::endl;
         ATemp_d = level_d->getA();
 
         for (int i = 0; i < ATemp_d.get_num_rows(); i++)
@@ -1518,7 +1518,7 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printConnections()
                 }
             }
 
-            connFile << endl;
+            connFile << std::endl;
         }
 
         level_d = level_d->next_d;
@@ -1529,7 +1529,7 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printConnections()
 
     while (level_h != NULL)
     {
-        connFile << level_h->level_id << " " << level_h->getNumRows() << endl;
+        connFile << level_h->level_id << " " << level_h->getNumRows() << std::endl;
         ATemp_d = level_h->getA();
 
         for (int i = 0; i < ATemp_h.get_num_rows(); i++)
@@ -1553,7 +1553,7 @@ void AMG<t_vecPrec, t_matPrec, t_indPrec>::printConnections()
                 }
             }
 
-            connFile << endl;
+            connFile << std::endl;
         }
 
         level_h = level_h->next_h;

--- a/src/amg_config.cu
+++ b/src/amg_config.cu
@@ -44,7 +44,6 @@
 #include "rapidjson/filestream.h"
 #endif
 
-using namespace std;
 namespace amgx
 {
 
@@ -94,7 +93,7 @@ AMGX_ERROR AMG_Config::parseParameterString(const char *str)
         {
 #endif
             //copy to a temporary array to avoid destroying the string
-            string params(str);
+            std::string params(str);
             // Read the config version
             int config_version = getConfigVersion(params);
 
@@ -178,7 +177,7 @@ int AMG_Config::getConfigVersion(std::string &params)
     if (param.length() > 2 && param.find_first_not_of(' ') != std::string::npos) /* check that param is not empty and check length: one for parameter name, one for the equal sign, one for the parameter value. otherwise - this is error */
     {
         // Extract the name, value, current_scope, new_scope
-        string name, value, current_scope, new_scope;
+        std::string name, value, current_scope, new_scope;
         extractParamInfo(param, name, value, current_scope, new_scope);
         int config_version;
 
@@ -288,7 +287,7 @@ AMGX_ERROR AMG_Config::parseString(std::string &params, int &config_version)
 
             while (params[pos] == ' ') { pos++; }  // skip spaces
 
-            bool print = (pos == string::npos) || (params[pos] > '2');
+            bool print = (pos == std::string::npos) || (params[pos] > '2');
             std::string ss = "Converting config string to current config version\n";
 
             if (print)
@@ -343,7 +342,7 @@ AMGX_ERROR AMG_Config::parseString(std::string &params, int &config_version)
 
 AMGX_ERROR AMG_Config::getParameterStringFromFile(const char *filename, std::string &params)
 {
-    ifstream fin;
+    std::ifstream fin;
 
     try
     {
@@ -360,7 +359,7 @@ AMGX_ERROR AMG_Config::getParameterStringFromFile(const char *filename, std::str
 
         while (!fin.eof())
         {
-            string line;
+            std::string line;
             std::getline(fin, line);
             line = trim(line);
 
@@ -435,14 +434,14 @@ std::string AMG_Config::getParamTypeName(const std::type_info *param_type)
 }
 
 template<typename T>
-void AMG_Config::setNamedParameter(const string &name, const T &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
+void AMG_Config::setNamedParameter(const std::string &name, const T &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
 {
-    string err = "Parameter " + name + "(" + current_scope + ") is of unknown type, cannot import value.";
+    std::string err = "Parameter " + name + "(" + current_scope + ") is of unknown type, cannot import value.";
     FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
 }
 
 template<>
-void AMG_Config::setNamedParameter(const string &name, const std::string &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
+void AMG_Config::setNamedParameter(const std::string &name, const std::string &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
 {
     if (*(param_desc_iter->second.type) == typeid(AlgorithmType))
     {
@@ -470,13 +469,13 @@ void AMG_Config::setNamedParameter(const string &name, const std::string &c_valu
     }
     else
     {
-        string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is string, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
+        std::string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is string, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 }
 
 template<>
-void AMG_Config::setNamedParameter(const string &name, const double &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
+void AMG_Config::setNamedParameter(const std::string &name, const double &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
 {
     if (typeid(double) == *(param_desc_iter->second.type))
     {
@@ -489,13 +488,13 @@ void AMG_Config::setNamedParameter(const string &name, const double &c_value, co
     }
     else
     {
-        string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is double, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
+        std::string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is double, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 }
 
 template<>
-void AMG_Config::setNamedParameter(const string &name, const int &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
+void AMG_Config::setNamedParameter(const std::string &name, const int &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter)
 {
     if (typeid(int) == *(param_desc_iter->second.type))
     {
@@ -508,7 +507,7 @@ void AMG_Config::setNamedParameter(const string &name, const int &c_value, const
     }
     else
     {
-        string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is int, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
+        std::string err = "Incorrect config entry. Type of the parameter \"" + name + "\" in the config is int, but " + getParamTypeName(param_desc_iter->second.type) + " is expected";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 }
@@ -532,24 +531,24 @@ void AMG_Config::importNamedParameter(const char *c_name, const T &c_value, cons
 
     // extract the name, value, new_scope and old_scope
     //verify parameter was registered
-    ParamDesc::iterator iter = param_desc.find(string(name));
+    ParamDesc::iterator iter = param_desc.find(std::string(name));
 
     if (iter == param_desc.end())
     {
-        string err = "Variable '" + string(name) + "' not registered";
+        std::string err = "Variable '" + std::string(name) + "' not registered";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     if ( (name == "determinism_flag" || name == "block_format" || name == "separation_interior" || name == "separation_exterior" || name == "min_rows_latency_hiding" || name == "fine_level_consolidation" || name == "use_cuda_ipc_consolidation") && current_scope != "default" )
     {
-        string err = "Incorrect config entry. Parameter " + name + " can only be specified with default scope.";
+        std::string err = "Incorrect config entry. Parameter " + name + " can only be specified with default scope.";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     // Check that new scope is only associated with a solver
     if (new_scope != "default" && find(m_solver_list.begin(), m_solver_list.end(), name) == m_solver_list.end() )
     {
-        string err = "Incorrect config entry. New scope can only be associated with a solver. new_scope=" + new_scope + ", name=" + name + ".";
+        std::string err = "Incorrect config entry. New scope can only be associated with a solver. new_scope=" + new_scope + ", name=" + name + ".";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
@@ -631,7 +630,7 @@ void AMG_Config::import_json_object(rapidjson::Value &obj, bool outer)
 
 AMGX_ERROR AMG_Config::parse_json_file(const char *filename)
 {
-    ifstream fin;
+    std::ifstream fin;
 
     try
     {
@@ -648,7 +647,7 @@ AMGX_ERROR AMG_Config::parse_json_file(const char *filename)
 
         while (!fin.eof())
         {
-            string line;
+            std::string line;
             std::getline(fin, line);
 
             //line=trim(line);
@@ -984,7 +983,7 @@ AMGX_ERROR AMG_Config::parseFile(const char *filename)
 }
 
 template <typename Type>
-void AMG_Config::getParameter(const string &name, Type &value, const string &current_scope, string &new_scope) const
+void AMG_Config::getParameter(const std::string &name, Type &value, const std::string &current_scope, std::string &new_scope) const
 {
     //verify the parameter has been registered
     ParamDesc::const_iterator desc_iter = param_desc.find(name);
@@ -992,14 +991,14 @@ void AMG_Config::getParameter(const string &name, Type &value, const string &cur
 
     if (desc_iter == param_desc.end())
     {
-        err = "getParameter error: '" + string(name) + "' not found\n";
+        err = "getParameter error: '" + std::string(name) + "' not found\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     //verify the types match
     if (desc_iter->second.type != &typeid(Type))
     {
-        err = "getParameter error: '" + string(name) + "' type miss match\n";
+        err = "getParameter error: '" + std::string(name) + "' type miss match\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
@@ -1020,7 +1019,7 @@ void AMG_Config::getParameter(const string &name, Type &value, const string &cur
 }
 
 template <typename Type>
-Type AMG_Config::getParameter(const string &name, const string &current_scope) const
+Type AMG_Config::getParameter(const std::string &name, const std::string &current_scope) const
 {
     Type value;
     std::string new_scope;
@@ -1040,13 +1039,13 @@ void AMG_Config::setParameter(std::string name, Type value, const std::string &c
 
     if (iter == param_desc.end())
     {
-        err = "setParameter error: '" + string(name) + "' not found\n";
+        err = "setParameter error: '" + std::string(name) + "' not found\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     if (iter->second.type != &typeid(Type))
     {
-        err = "setParameter error: '" + string(name) + "' type miss match\n";
+        err = "setParameter error: '" + std::string(name) + "' type miss match\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
@@ -1078,13 +1077,13 @@ void AMG_Config::setParameter(std::string name, void *value, const std::string &
 
     if (iter == param_desc.end())
     {
-        err = "setParameter error: '" + string(name) + "' not found\n";
+        err = "setParameter error: '" + std::string(name) + "' not found\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     if (iter->second.type != &typeid(void *))
     {
-        err = "setParameter error: '" + string(name) + "' type miss match\n";
+        err = "setParameter error: '" + std::string(name) + "' type miss match\n";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
@@ -1099,9 +1098,9 @@ void AMG_Config::setParameter(std::string name, void *value, const std::string &
 
 std::string AMG_Config::getParameterString(Parameter &parameter, ParameterDescription &param_desc)
 {
-    stringstream ss;
+    std::stringstream ss;
 
-    if (*(param_desc.type) == typeid(string))
+    if (*(param_desc.type) == typeid(std::string))
     {
         ss << parameter.get<std::string>() ;
     }
@@ -1147,7 +1146,7 @@ std::string AMG_Config::getParameterString(Parameter &parameter, ParameterDescri
     }
     else
     {
-        string err = "getParameterString is not implemented for the datatype of value'" + param_desc.name + "'";
+        std::string err = "getParameterString is not implemented for the datatype of value'" + param_desc.name + "'";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
@@ -1161,7 +1160,7 @@ void AMG_Config::printOptions()
 
     for (ParamDesc::iterator iter = param_desc.begin(); iter != param_desc.end(); iter++)
     {
-        ss << "           " << iter->second.name << ": " << iter->second.description << endl;
+        ss << "           " << iter->second.name << ": " << iter->second.description << std::endl;
     }
 
     amgx_output(ss.str().c_str(), ss.str().length());
@@ -1174,11 +1173,11 @@ void AMG_Config::printAMGConfig()
     int devId;
     cudaGetDevice(&devId);
     cudaDeviceProp deviceProp = getDeviceProperties();
-    //ss << "HP Scalar Type: " << scalar_hp << endl;
-    //ss << "LP Scalar Type: " << scalar_lp << endl;
-    ss << "Device " << devId << ": " << deviceProp.name << endl;
-    ss << "AMG Configuration: "  << endl;
-    config_ss << endl;
+    //ss << "HP Scalar Type: " << scalar_hp << std::endl;
+    //ss << "LP Scalar Type: " << scalar_lp << std::endl;
+    ss << "Device " << devId << ": " << deviceProp.name << std::endl;
+    ss << "AMG Configuration: "  << std::endl;
+    config_ss << std::endl;
     config_ss << "Default values:" << std::endl ;
     config_ss << std::endl;
 
@@ -1186,7 +1185,7 @@ void AMG_Config::printAMGConfig()
     {
         config_ss << "            " << iter->second.name << " = ";
         config_ss << getParameterString(iter->second.default_value, iter->second);
-        config_ss << endl;
+        config_ss << std::endl;
     }
 
     config_ss << std::endl;
@@ -1210,17 +1209,17 @@ void AMG_Config::printAMGConfig()
 
         config_ss << " = " ;
         config_ss << getParameterString(iter->second.second, desc_iter->second);
-        config_ss << endl;
+        config_ss << std::endl;
     }
 
-    config_ss << endl;
+    config_ss << std::endl;
     amgx_output(ss.str().c_str(), ss.str().length());
     amgx_output(config_ss.str().c_str(), config_ss.str().length());
 }
 
 AMGX_ERROR AMG_Config::checkString(std::string &str)
 {
-    string::iterator it;
+    std::string::iterator it;
 
     for (it = str.begin(); it < str.end(); it++)
     {
@@ -1240,9 +1239,9 @@ AMGX_ERROR AMG_Config::checkString(std::string &str)
     return AMGX_OK;
 }
 
-void AMG_Config::extractParamInfo(const string &str, string &name, string &value, string &current_scope, string &new_scope)
+void AMG_Config::extractParamInfo(const std::string &str, std::string &name, std::string &value, std::string &current_scope, std::string &new_scope)
 {
-    string tmp(str);
+    std::string tmp(str);
 
     //locate the split
     if ( std::count(tmp.begin(), tmp.end(), '=') != 1)
@@ -1327,10 +1326,10 @@ void AMG_Config::extractParamInfo(const string &str, string &name, string &value
 }
 
 
-void AMG_Config::setParameter(const string &str)
+void AMG_Config::setParameter(const std::string &str)
 {
-    string name, value, current_scope, new_scope;
-    string tmp;
+    std::string name, value, current_scope, new_scope;
+    std::string tmp;
     extractParamInfo(str, name, value, current_scope, new_scope);
 
     // Add new_scope to scope vector
@@ -1346,29 +1345,29 @@ void AMG_Config::setParameter(const string &str)
 
     // extract the name, value, new_scope and old_scope
     //verify parameter was registered
-    ParamDesc::iterator iter = param_desc.find(string(name));
+    ParamDesc::iterator iter = param_desc.find(std::string(name));
 
     if (iter == param_desc.end())
     {
-        string err = "Variable '" + string(name) + "' not registered";
+        std::string err = "Variable '" + std::string(name) + "' not registered";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     if ( (name == "determinism_flag" || name == "block_format" || name == "separation_interior" || name == "separation_exterior" || name == "min_rows_latency_hiding" || name == "fine_level_consolidation" || name == "use_cuda_ipc_consolidation") && current_scope != "default" )
     {
-        string err = "Incorrect config entry. Parameter " + name + " can only be specified with default scope.";
+        std::string err = "Incorrect config entry. Parameter " + name + " can only be specified with default scope.";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     // Check that new scope is only associated with a solver
     if (new_scope != "default" && find(m_solver_list.begin(), m_solver_list.end(), name) == m_solver_list.end() )
     {
-        string err = "Incorrect config entry. New scope can only be associated with a solver. new_scope=" + new_scope + ", name=" + name + ".";
+        std::string err = "Incorrect config entry. New scope can only be associated with a solver. new_scope=" + new_scope + ", name=" + name + ".";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 
     // Set the new parameter name, value
-    if (*(iter->second.type) == typeid(string))
+    if (*(iter->second.type) == typeid(std::string))
     {
         setParameter(name, value, current_scope, new_scope);
     }
@@ -1410,7 +1409,7 @@ void AMG_Config::setParameter(const string &str)
     }
     else
     {
-        string err = "getValue is not implemented for the datatype of variable '" + name + "'";
+        std::string err = "getValue is not implemented for the datatype of variable '" + name + "'";
         FatalError(err.c_str(), AMGX_ERR_CONFIGURATION);
     }
 }
@@ -1435,7 +1434,7 @@ void AMG_Config::clear()
 
 
 // Template specialization
-template string AMG_Config::getParameter(const std::string &, const std::string &) const;
+template std::string AMG_Config::getParameter(const std::string &, const std::string &) const;
 template AlgorithmType AMG_Config::getParameter(const std::string &, const std::string &) const;
 template ViewType AMG_Config::getParameter(const std::string &, const std::string &) const;
 template ColoringType AMG_Config::getParameter(const std::string &, const std::string &) const;

--- a/src/classical/interpolators/interpolator.cu
+++ b/src/classical/interpolators/interpolator.cu
@@ -30,7 +30,6 @@
 
 #include <assert.h>
 
-using namespace std;
 namespace amgx
 {
 
@@ -43,14 +42,14 @@ InterpolatorFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void InterpolatorFactory<TConfig>::registerFactory(string name, InterpolatorFactory<TConfig> *f)
+void InterpolatorFactory<TConfig>::registerFactory(std::string name, InterpolatorFactory<TConfig> *f)
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "InterpolatorFactory '" + name + "' has already been registered\n";
+        std::string error = "InterpolatorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -79,7 +78,7 @@ template<class TConfig>
 void InterpolatorFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, InterpolatorFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -96,12 +95,12 @@ template<class TConfig>
 Interpolator<TConfig> *InterpolatorFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    string interpolator = cfg.getParameter<string>("interpolator", cfg_scope);
-    typename map<string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(interpolator);
+    std::string interpolator = cfg.getParameter<std::string>("interpolator", cfg_scope);
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(interpolator);
 
     if (it == factories.end())
     {
-        string error = "InterpolatorFactory '" + interpolator + "' has not been registered\n";
+        std::string error = "InterpolatorFactory '" + interpolator + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/classical/selectors/selector.cu
+++ b/src/classical/selectors/selector.cu
@@ -36,7 +36,6 @@
 
 namespace amgx
 {
-using namespace std;
 namespace classical
 {
 
@@ -1218,14 +1217,14 @@ SelectorFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void SelectorFactory<TConfig>::registerFactory(string name, SelectorFactory<TConfig> *f)
+void SelectorFactory<TConfig>::registerFactory(std::string name, SelectorFactory<TConfig> *f)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "SelectorFactory '" + name + "' has already been registered\n";
+        std::string error = "SelectorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -1236,11 +1235,11 @@ template<class TConfig>
 void SelectorFactory<TConfig>::unregisterFactory(std::string name)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, SelectorFactory<TConfig> *>::iterator it = factories.find(name);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.find(name);
 
     if (it == factories.end())
     {
-        string error = "SelectorFactory '" + name + "' has not been registered\n";
+        std::string error = "SelectorFactory '" + name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -1254,7 +1253,7 @@ template<class TConfig>
 void SelectorFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -1271,12 +1270,12 @@ template<class TConfig>
 Selector<TConfig> *SelectorFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    string selector = cfg.getParameter<string>("selector", cfg_scope);
-    typename map<string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(selector);
+    std::string selector = cfg.getParameter<std::string>("selector", cfg_scope);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(selector);
 
     if (it == factories.end())
     {
-        string error = "SelectorFactory '" + selector + "' has not been registered\n";
+        std::string error = "SelectorFactory '" + selector + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/classical/strength/strength.cu
+++ b/src/classical/strength/strength.cu
@@ -35,8 +35,6 @@
 
 namespace amgx
 {
-using namespace std;
-
 template<class TConfig>
 std::map<std::string, StrengthFactory<TConfig>*> &
 StrengthFactory<TConfig>::getFactories( )
@@ -46,14 +44,14 @@ StrengthFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void StrengthFactory<TConfig>::registerFactory(string name, StrengthFactory<TConfig> *f)
+void StrengthFactory<TConfig>::registerFactory(std::string name, StrengthFactory<TConfig> *f)
 {
     std::map<std::string, StrengthFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, StrengthFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, StrengthFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "StrengthFactory '" + name + "' has already been registered\n";
+        std::string error = "StrengthFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -82,7 +80,7 @@ template<class TConfig>
 void StrengthFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, StrengthFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, StrengthFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, StrengthFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -99,12 +97,12 @@ template<class TConfig>
 Strength<TConfig> *StrengthFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, StrengthFactory<TConfig>*> &factories = getFactories( );
-    string strength = cfg.getParameter<string>("strength", cfg_scope);
-    typename map<string, StrengthFactory<TConfig> *>::const_iterator it = factories.find(strength);
+    std::string strength = cfg.getParameter<std::string>("strength", cfg_scope);
+    typename std::map<std::string, StrengthFactory<TConfig> *>::const_iterator it = factories.find(strength);
 
     if (it == factories.end())
     {
-        string error = "StrengthFactory '" + strength + "' has not been registered\n";
+        std::string error = "StrengthFactory '" + strength + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/cycles/cycle.cu
+++ b/src/cycles/cycle.cu
@@ -36,8 +36,6 @@
 
 namespace amgx
 {
-using namespace std;
-
 
 // Methods to check if Ax=b is easily invertible
 template <class T_Config>
@@ -117,14 +115,14 @@ CycleFactory<T_Config>::getFactories( )
 }
 
 template<class T_Config>
-void CycleFactory<T_Config>::registerFactory(string name, CycleFactory<T_Config> *f)
+void CycleFactory<T_Config>::registerFactory(std::string name, CycleFactory<T_Config> *f)
 {
     std::map<std::string, CycleFactory<T_Config>*> &factories = getFactories( );
-    typename map<string, CycleFactory<T_Config> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, CycleFactory<T_Config> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "CycleFactory '" + name + "' has already been registered\n";
+        std::string error = "CycleFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -153,7 +151,7 @@ template<class T_Config>
 void CycleFactory<T_Config>::unregisterFactories( )
 {
     std::map<std::string, CycleFactory<T_Config>*> &factories = getFactories( );
-    typename map<std::string, CycleFactory<T_Config> *>::iterator it = factories.begin( );
+    typename std::map<std::string, CycleFactory<T_Config> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -170,12 +168,12 @@ template<class T_Config>
 Cycle<T_Config> *CycleFactory<T_Config>::allocate(AMG_Class *amg, AMG_Level<T_Config> *level, VVector &b, VVector &c)
 {
     std::map<std::string, CycleFactory<T_Config>*> &factories = getFactories( );
-    std::string cycle_name = amg->m_cfg->AMG_Config::getParameter<string>("cycle", amg->m_cfg_scope);
-    typename map<string, CycleFactory<T_Config> *>::const_iterator it = factories.find(cycle_name);
+    std::string cycle_name = amg->m_cfg->AMG_Config::getParameter<std::string>("cycle", amg->m_cfg_scope);
+    typename std::map<std::string, CycleFactory<T_Config> *>::const_iterator it = factories.find(cycle_name);
 
     if (it == factories.end())
     {
-        string error = "CycleFactory '" + cycle_name + "' has not been registered\n";
+        std::string error = "CycleFactory '" + cycle_name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/distributed/distributed_comms.cu
+++ b/src/distributed/distributed_comms.cu
@@ -31,7 +31,6 @@
 #include <types.h>
 #include <assert.h>
 
-using namespace std;
 namespace amgx
 {
 

--- a/src/distributed/distributed_manager.cu
+++ b/src/distributed/distributed_manager.cu
@@ -64,7 +64,6 @@ struct is_my_part : public amgx::thrust::unary_function<int, bool>
     }
 };
 
-using namespace std;
 namespace amgx
 {
 
@@ -1076,14 +1075,14 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>
 template <typename t_colIndex>
-map<t_colIndex, int> DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::loadDistributed_LocalToGlobal(int num_rows, I64Vector_h &off_diag_cols)
+std::map<t_colIndex, int> DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::loadDistributed_LocalToGlobal(int num_rows, I64Vector_h &off_diag_cols)
 {
     // sort global column indices
     amgx::thrust::sort(off_diag_cols.begin(), off_diag_cols.end());
     // find unique columns and set local <-> global mappings
     // 1) Removed unneeded vector 2) Create map on host first, upload later (less thrust calls)
     I64Vector_h local_to_global_h;
-    map<t_colIndex, int> global_to_local;        // temporary
+    std::map<t_colIndex, int> global_to_local;        // temporary
 
     if (off_diag_cols.size() > 0)
     {

--- a/src/energymin/interpolators/em_interpolator.cu
+++ b/src/energymin/interpolators/em_interpolator.cu
@@ -30,7 +30,6 @@
 
 #include <assert.h>
 
-using namespace std;
 namespace amgx
 {
 namespace energymin
@@ -45,14 +44,14 @@ InterpolatorFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void InterpolatorFactory<TConfig>::registerFactory(string name, InterpolatorFactory<TConfig> *f)
+void InterpolatorFactory<TConfig>::registerFactory(std::string name, InterpolatorFactory<TConfig> *f)
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "InterpolatorFactory '" + name + "' has already been registered\n";
+        std::string error = "InterpolatorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -81,7 +80,7 @@ template<class TConfig>
 void InterpolatorFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, InterpolatorFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -98,12 +97,12 @@ template<class TConfig>
 Interpolator<TConfig> *InterpolatorFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, InterpolatorFactory<TConfig>*> &factories = getFactories( );
-    string interpolator = cfg.getParameter<string>("energymin_interpolator", cfg_scope);
-    typename map<string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(interpolator);
+    std::string interpolator = cfg.getParameter<std::string>("energymin_interpolator", cfg_scope);
+    typename std::map<std::string, InterpolatorFactory<TConfig> *>::const_iterator it = factories.find(interpolator);
 
     if (it == factories.end())
     {
-        string error = "InterpolatorFactory '" + interpolator + "' has not been registered\n";
+        std::string error = "InterpolatorFactory '" + interpolator + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/energymin/selectors/em_selector.cu
+++ b/src/energymin/selectors/em_selector.cu
@@ -32,7 +32,6 @@
 
 namespace amgx
 {
-using namespace std;
 namespace energymin
 {
 
@@ -47,14 +46,14 @@ SelectorFactory<TConfig>
 
 template<class TConfig>
 void SelectorFactory<TConfig>
-::registerFactory(string name, SelectorFactory<TConfig> *f)
+::registerFactory(std::string name, SelectorFactory<TConfig> *f)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "SelectorFactory '" + name + "' has already been registered\n";
+        std::string error = "SelectorFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -66,11 +65,11 @@ void SelectorFactory<TConfig>
 ::unregisterFactory(std::string name)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, SelectorFactory<TConfig> *>::iterator it = factories.find(name);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.find(name);
 
     if (it == factories.end())
     {
-        string error = "SelectorFactory '" + name + "' has not been registered\n";
+        std::string error = "SelectorFactory '" + name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -85,7 +84,7 @@ void SelectorFactory<TConfig>
 ::unregisterFactories( )
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, SelectorFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ); )
     {
@@ -103,12 +102,12 @@ Selector<TConfig> *SelectorFactory<TConfig>
 ::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, SelectorFactory<TConfig>*> &factories = getFactories( );
-    string selector = cfg.getParameter<string>("energymin_selector", cfg_scope);
-    typename map<string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(selector);
+    std::string selector = cfg.getParameter<std::string>("energymin_selector", cfg_scope);
+    typename std::map<std::string, SelectorFactory<TConfig> *>::const_iterator it = factories.find(selector);
 
     if (it == factories.end())
     {
-        string error = "SelectorFactory '" + selector + "' has not been registered\n";
+        std::string error = "SelectorFactory '" + selector + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/matrix_coloring/matrix_coloring.cu
+++ b/src/matrix_coloring/matrix_coloring.cu
@@ -43,7 +43,6 @@
 #include <amgx_types/util.h>
 #include <amgx_types/math.h>
 
-using namespace std;
 namespace amgx
 {
 /***************************************
@@ -360,14 +359,14 @@ MatrixColoringFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void MatrixColoringFactory<TConfig>::registerFactory(string name, MatrixColoringFactory<TConfig> *f)
+void MatrixColoringFactory<TConfig>::registerFactory(std::string name, MatrixColoringFactory<TConfig> *f)
 {
     std::map<std::string, MatrixColoringFactory<TConfig> *> &factories = getFactories( );
-    typename map<string, MatrixColoringFactory<TConfig> *>::iterator it = factories.find(name);
+    typename std::map<std::string, MatrixColoringFactory<TConfig> *>::iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "MatrixColoringFactory '" + name + "' has already been registered\n";
+        std::string error = "MatrixColoringFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -396,7 +395,7 @@ template<class TConfig>
 void MatrixColoringFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, MatrixColoringFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, MatrixColoringFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, MatrixColoringFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -413,12 +412,12 @@ template<class TConfig>
 MatrixColoring<TConfig> *MatrixColoringFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, MatrixColoringFactory<TConfig> *> &factories = getFactories( );
-    string matrix_coloring_scheme = cfg.getParameter<string>("matrix_coloring_scheme", cfg_scope);
-    typename map<string, MatrixColoringFactory<TConfig> *>::const_iterator it = factories.find(matrix_coloring_scheme);
+    std::string matrix_coloring_scheme = cfg.getParameter<std::string>("matrix_coloring_scheme", cfg_scope);
+    typename std::map<std::string, MatrixColoringFactory<TConfig> *>::const_iterator it = factories.find(matrix_coloring_scheme);
 
     if (it == factories.end())
     {
-        string error = "MatrixColoringFactory '" + matrix_coloring_scheme + "' has not been registered\n";
+        std::string error = "MatrixColoringFactory '" + matrix_coloring_scheme + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/matrix_io.cu
+++ b/src/matrix_io.cu
@@ -51,8 +51,6 @@
 #include "amgx_types/util.h"
 #include "amgx_types/io.h"
 
-using namespace std;
-
 namespace amgx
 {
 
@@ -64,7 +62,7 @@ MatrixIO<T_Config>::readerMap &MatrixIO<T_Config>::getReaderMap()
 }
 
 template<class T_Config>
-void MatrixIO<T_Config>::registerReader(string key, readerFunc func)
+void MatrixIO<T_Config>::registerReader(std::string key, readerFunc func)
 {
     readerMap &readers_map = getReaderMap();
     typename readerMap::const_iterator iter = readers_map.find(key);
@@ -93,7 +91,7 @@ MatrixIO<T_Config>::writerMap &MatrixIO<T_Config>::getWriterMap()
 }
 
 template<class T_Config>
-void MatrixIO<T_Config>::registerWriter(string key, writerFunc func)
+void MatrixIO<T_Config>::registerWriter(std::string key, writerFunc func)
 {
     writerMap &writer_map = getWriterMap();
     typename writerMap::const_iterator iter = writer_map.find(key);
@@ -131,7 +129,7 @@ bool MatrixIO<T_Config>::writeSystemMatrixMarket(const char *fname, const Matrix
     }
 
     std::ofstream fout;
-    std::string err = "Writing system to file " + string(fname) + "\n";
+    std::string err = "Writing system to file " + std::string(fname) + "\n";
     amgx_output(err.c_str(), err.length());
     fout.open(fname);
 
@@ -292,7 +290,7 @@ bool MatrixIO<T_Config>::writeSystemBinary(const char *fname, const Matrix<T_Con
 
     FILE *fout;
     const char header [] = "%%NVAMGBinary\n";
-    std::string err = "Writing system to file " + string(fname) + "\n";
+    std::string err = "Writing system to file " + std::string(fname) + "\n";
     amgx_output(err.c_str(), err.length());
     fout = fopen(fname, "wb");
 
@@ -420,11 +418,11 @@ AMGX_ERROR MatrixIO<T_Config>::readSystem(const char *fname
 
         if (io_config::hasProps(io_config::SIZE, props))
         {
-            err = "Reading matrix dimensions in file: " + string(fname) + "\n";
+            err = "Reading matrix dimensions in file: " + std::string(fname) + "\n";
         }
         else if (io_config::hasProps(io_config::PRINT, props))
         {
-            err = "Reading matrix in file: " + string(fname) + "\n";
+            err = "Reading matrix in file: " + std::string(fname) + "\n";
         }
 
         amgx_output(err.c_str(), err.length());
@@ -432,7 +430,7 @@ AMGX_ERROR MatrixIO<T_Config>::readSystem(const char *fname
 
         if (!fin)
         {
-            err = "Error opening file '" + string(fname) + "'\n";
+            err = "Error opening file '" + std::string(fname) + "'\n";
             FatalError(err.c_str(), AMGX_ERR_IO);
         }
 
@@ -442,7 +440,7 @@ AMGX_ERROR MatrixIO<T_Config>::readSystem(const char *fname
 
         if (fformat.substr(0, 2) != "%%")
         {
-            err = "Invalid header line in file " + string(fname) + " First line should begin with: %%MatrixFormat\n";
+            err = "Invalid header line in file " + std::string(fname) + " First line should begin with: %%MatrixFormat\n";
             FatalError(err.c_str(), AMGX_ERR_IO);
         }
         else
@@ -592,17 +590,17 @@ AMGX_ERROR MatrixIO<T_Config>::readSystem(const char *fname
 }
 
 template<class T_Config>
-string MatrixIO<T_Config>::readSystemFormat(const char *fname)
+std::string MatrixIO<T_Config>::readSystemFormat(const char *fname)
 {
     readerMap &readers_map = getReaderMap();
     //open file
-    std::string out = "Reading matrix format in file: " + string(fname) + "\n";
+    std::string out = "Reading matrix format in file: " + std::string(fname) + "\n";
     amgx_output(out.c_str(), out.length());
     std::ifstream fin(fname);
 
     if (!fin)
     {
-        out = "Error opening file: " + string(fname) + "\n";
+        out = "Error opening file: " + std::string(fname) + "\n";
         FatalError(out.c_str(), AMGX_ERR_IO);
     }
 
@@ -627,12 +625,12 @@ string MatrixIO<T_Config>::readSystemFormat(const char *fname)
 AMGX_ERROR MatrixIO<T_Config>::readGeometry( AuxData* obj, const char* fname)
 {
   std::string err;
-  err = "Reading matrix in file: " + string(fname) + "\n";
+  err = "Reading matrix in file: " + std::string(fname) + "\n";
   amgx_output(err.c_str(), err.length());
 
   std::ifstream fin(fname);
   if(!fin) {
-    err = "Error opening file '" + string(fname) + "'\n";
+    err = "Error opening file '" + std::string(fname) + "'\n";
       FatalError(err.c_str(), AMGX_ERR_IO);
   }
 
@@ -676,12 +674,12 @@ template<class T_Config>
 AMGX_ERROR MatrixIO<T_Config>::readColoring( AuxData* obj, const char* fname)
 {
   std::string err;
-  err = "Reading matrix in file: " + string(fname) + "\n";
+  err = "Reading matrix in file: " + std::string(fname) + "\n";
   amgx_output(err.c_str(), err.length());
 
   std::ifstream fin(fname);
   if(!fin) {
-    err = "Error opening file '" + string(fname) + "'\n";
+    err = "Error opening file '" + std::string(fname) + "'\n";
       FatalError(err.c_str(), AMGX_ERR_IO);
   }
 

--- a/src/readers.cu
+++ b/src/readers.cu
@@ -129,7 +129,7 @@ bool LoadVector(std::ifstream &fin, bool read_all, int rows_total, int block_siz
 }
 
 // Distrubuted version
-void skip_vals(ifstream &fin, int num_values)
+void skip_vals(std::ifstream &fin, int num_values)
 {
     double val;
 
@@ -689,8 +689,8 @@ bool ReadMatrixMarket<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec>
     }
 
     //skip comments and read amgx relevant parameters
-    std::list<string> nvConfig;
-    std::list<string> mmConfig;
+    std::list<std::string> nvConfig;
+    std::list<std::string> mmConfig;
     // Workaround section to convert external diagonal into internal
     // in CLASSICAL
     bool isClassical = false;
@@ -735,14 +735,14 @@ bool ReadMatrixMarket<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec>
             if ((nvFormat.substr(2, nvFormat.size()) == "nvamg") ||
                     (nvFormat.substr(2, nvFormat.size()) == "amgx"))
             {
-                std::copy(istream_iterator<string>(nvString_s), istream_iterator<string>(),
-                          back_inserter<list<string> >(nvConfig));
+                std::copy(std::istream_iterator<std::string>(nvString_s), std::istream_iterator<std::string>(),
+                          std::back_inserter<std::list<std::string> >(nvConfig));
             }
 
             if (nvFormat.substr(2, nvFormat.size()) == "matrixmarket")
             {
-                std::copy(istream_iterator<string>(nvString_s), istream_iterator<string>(),
-                          back_inserter<list<string> >(mmConfig));
+                std::copy(std::istream_iterator<std::string>(nvString_s), std::istream_iterator<std::string>(),
+                          std::back_inserter<std::list<std::string> >(mmConfig));
             }
         }
 
@@ -757,7 +757,7 @@ bool ReadMatrixMarket<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec>
 
     if (mmConfig.size() > 0)
     {
-        for (list<string>::const_iterator it = mmConfig.begin(); it != mmConfig.end(); ++it)
+        for (std::list<std::string>::const_iterator it = mmConfig.begin(); it != mmConfig.end(); ++it)
         {
             if (*it == "symmetric") {symmetric = true; continue;}
 
@@ -791,11 +791,11 @@ bool ReadMatrixMarket<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec>
     // process amgx config string
     int block_dimx = 1, block_dimy = 1, index_base = 1;
     bool diag_prop = false, rhs = false, soln = false, mtx = false, sorted = false;
-    list<int> block_sizes;
+    std::list<int> block_sizes;
 
     if (nvConfig.size() > 0)
     {
-        for (list<string>::const_iterator it = nvConfig.begin(); it != nvConfig.end(); ++it)
+        for (std::list<std::string>::const_iterator it = nvConfig.begin(); it != nvConfig.end(); ++it)
         {
             if (*it == "diagonal") {diag_prop = true; continue;}
 
@@ -807,7 +807,7 @@ bool ReadMatrixMarket<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec>
 
             if (*it == "base0") {index_base = 0; continue;}
 
-            if (isdigit((*it)[0])) { int bsize; istringstream(*it) >> bsize; block_sizes.push_back(bsize); continue;};
+            if (isdigit((*it)[0])) { int bsize; std::istringstream(*it) >> bsize; block_sizes.push_back(bsize); continue;};
         }
     }
 
@@ -1838,7 +1838,7 @@ bool ReadNVAMGBinary<TemplateConfig<AMGX_host, t_vecPrec, t_matPrec, t_indPrec> 
     data_pos += num_nz * sizeof(int);
     //temperary array for storing ValueTypeA data
     // double storage for complex
-    vector< UpValueTypeA > temp(n_nonzeros_part * block_dimy * block_dimx);
+    std::vector< UpValueTypeA > temp(n_nonzeros_part * block_dimy * block_dimx);
     n_nonzeros_part = 0;
 
     for (int i = 0; i < partRowVec.size(); i++)

--- a/src/scalers/binormalization.cu
+++ b/src/scalers/binormalization.cu
@@ -277,7 +277,7 @@ void computeBetaDevice(const int nrows, IndexType *offsets, IndexType *indices, 
 
 
 template<typename T>
-struct square_value : public unary_function<T, T>
+struct square_value : public thrust::unary_function<T, T>
 {
     __host__ __device__ T operator()(const T &x) const
     {

--- a/src/scalers/nbinormalization.cu
+++ b/src/scalers/nbinormalization.cu
@@ -308,7 +308,7 @@ void setOneOverVector(int N, ValueType *x, ValueType sum1, ValueType *beta)
 }
 
 template<typename T>
-struct square_value : public unary_function<T, T>
+struct square_value : public thrust::unary_function<T, T>
 {
     __host__ __device__ T operator()(const T &x) const
     {

--- a/src/scalers/scaler.cu
+++ b/src/scalers/scaler.cu
@@ -79,14 +79,14 @@ ScalerFactory<TConfig>::getFactories( )
 }
 
 template<class TConfig>
-void ScalerFactory<TConfig>::registerFactory(string name, ScalerFactory<TConfig> *f)
+void ScalerFactory<TConfig>::registerFactory(std::string name, ScalerFactory<TConfig> *f)
 {
     std::map<std::string, ScalerFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, ScalerFactory<TConfig> *>::const_iterator it = factories.find(name);
+    typename std::map<std::string, ScalerFactory<TConfig> *>::const_iterator it = factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "ScalerFactory '" + name + "' has already been registered\n";
+        std::string error = "ScalerFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -97,11 +97,11 @@ template<class TConfig>
 void ScalerFactory<TConfig>::unregisterFactory(std::string name)
 {
     std::map<std::string, ScalerFactory<TConfig>*> &factories = getFactories( );
-    typename map<string, ScalerFactory<TConfig> *>::iterator it = factories.find(name);
+    typename std::map<std::string, ScalerFactory<TConfig> *>::iterator it = factories.find(name);
 
     if (it == factories.end())
     {
-        string error = "ScalerFactory '" + name + "' has not been registered\n";
+        std::string error = "ScalerFactory '" + name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -115,7 +115,7 @@ template<class TConfig>
 void ScalerFactory<TConfig>::unregisterFactories( )
 {
     std::map<std::string, ScalerFactory<TConfig>*> &factories = getFactories( );
-    typename map<std::string, ScalerFactory<TConfig> *>::iterator it = factories.begin( );
+    typename std::map<std::string, ScalerFactory<TConfig> *>::iterator it = factories.begin( );
 
     for ( ; it != factories.end( ) ; )
     {
@@ -132,12 +132,12 @@ template<class TConfig>
 Scaler<TConfig> *ScalerFactory<TConfig>::allocate(AMG_Config &cfg, const std::string &cfg_scope)
 {
     std::map<std::string, ScalerFactory<TConfig>*> &factories = getFactories( );
-    string scaler = cfg.getParameter<string>("scaling", cfg_scope);
-    typename map<string, ScalerFactory<TConfig> *>::const_iterator it = factories.find(scaler);
+    std::string scaler = cfg.getParameter<std::string>("scaling", cfg_scope);
+    typename std::map<std::string, ScalerFactory<TConfig> *>::const_iterator it = factories.find(scaler);
 
     if (it == factories.end())
     {
-        string error = "ScalerFactory '" + scaler + "' has not been registered\n";
+        std::string error = "ScalerFactory '" + scaler + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 

--- a/src/solvers/block_jacobi_solver.cu
+++ b/src/solvers/block_jacobi_solver.cu
@@ -39,7 +39,6 @@
 
 #include <amgx_types/util.h>
 
-using namespace std;
 namespace amgx
 {
 namespace block_jacobi_solver

--- a/src/solvers/cf_jacobi_solver.cu
+++ b/src/solvers/cf_jacobi_solver.cu
@@ -38,7 +38,6 @@
 
 #include <thrust/partition.h>
 
-using namespace std;
 namespace amgx
 {
 namespace cf_jacobi_solver

--- a/src/solvers/chebyshev_poly.cu
+++ b/src/solvers/chebyshev_poly.cu
@@ -40,7 +40,6 @@
 
 #undef DEBUG_CHEBYSHEV_OUTPUT
 
-using namespace std;
 namespace amgx
 {
 namespace chebyshev_poly_smoother

--- a/src/solvers/fixcolor_gauss_seidel_solver.cu
+++ b/src/solvers/fixcolor_gauss_seidel_solver.cu
@@ -37,7 +37,6 @@
 #include <util.h>
 #include <texture.h>
 
-using namespace std;
 namespace amgx
 {
 namespace fixcolor_gauss_seidel_solver

--- a/src/solvers/idr_solver.cu
+++ b/src/solvers/idr_solver.cu
@@ -35,7 +35,6 @@
 #include <sstream>
 #include <curand.h>
 
-using namespace std;
 namespace amgx
 {
 namespace idr_solver
@@ -338,7 +337,7 @@ IDR_Solver_Base<T_Config>::solve_iteration( VVector &b, VVector &x, bool xIsZero
 
     if (this->omega == 0)
     {
-        cout << "Error happened in this->omega==0" << endl;
+        std::cout << "Error happened in this->omega==0" << std::endl;
         exit(1);
     }
 

--- a/src/solvers/idrmsync_solver.cu
+++ b/src/solvers/idrmsync_solver.cu
@@ -36,7 +36,6 @@
 #include <curand.h>
 #include <solvers/block_common_solver.h>
 
-using namespace std;
 namespace amgx
 {
 namespace idrmsync_solver
@@ -412,7 +411,7 @@ IDRMSYNC_Solver_Base<T_Config>::solve_iteration( VVector &b, VVector &x, bool xI
 
     if (this->omega == (ValueTypeB) 0)
     {
-        cout << "Error happened in this->omega==0" << endl;
+        std::cout << "Error happened in this->omega==0" << std::endl;
         exit(1);
     }
 

--- a/src/solvers/multicolor_dilu_solver.cu
+++ b/src/solvers/multicolor_dilu_solver.cu
@@ -47,7 +47,6 @@
 
 #define AMGX_ILU_COLORING
 
-using namespace std;
 namespace amgx
 {
 namespace multicolor_dilu_solver

--- a/src/solvers/multicolor_gauss_seidel_solver.cu
+++ b/src/solvers/multicolor_gauss_seidel_solver.cu
@@ -41,7 +41,6 @@
 
 #include "sm_utils.inl"
 
-using namespace std;
 namespace amgx
 {
 namespace multicolor_gauss_seidel_solver

--- a/src/solvers/multicolor_ilu_solver.cu
+++ b/src/solvers/multicolor_ilu_solver.cu
@@ -53,7 +53,6 @@
 #define EXPERIMENTAL_LU_FORWARD
 #define EXPERIMENTAL_LU_BACKWARD
 
-using namespace std;
 namespace amgx
 {
 

--- a/src/solvers/solver.cu
+++ b/src/solvers/solver.cu
@@ -900,14 +900,14 @@ AMGX_STATUS Solver<TConfig>::solve(Vector<TConfig> &b, Vector<TConfig> &x,
         }
 
         ss << std::endl;
-        ss << "         Total Iterations: " << m_num_iters << endl;
+        ss << "         Total Iterations: " << m_num_iters << std::endl;
         ss << "         Avg Convergence Rate: \t\t";
 
         for (int i = 0; i < last_nrm.size(); i++)
             ss << std::fixed << std::setw(15)
                << ((m_nrm_ini[i] > eps) ? pow(last_nrm[i] / m_nrm_ini[i],  types::util<PODValueB>::get_one() / m_num_iters) : m_nrm_ini[i]);
 
-        ss << endl;
+        ss << std::endl;
         ss << "         Final Residual: \t\t" << std::setprecision(6);
 
         for (int i = 0; i < last_nrm.size(); i++)
@@ -915,7 +915,7 @@ AMGX_STATUS Solver<TConfig>::solve(Vector<TConfig> &b, Vector<TConfig> &x,
             ss << std::scientific << std::setw(15) << last_nrm[i] << std::fixed;
         }
 
-        ss << endl;
+        ss << std::endl;
         ss << "         Total Reduction in Residual: \t" << std::setprecision(6);
 
         for (int i = 0; i < last_nrm.size(); i++)
@@ -923,7 +923,7 @@ AMGX_STATUS Solver<TConfig>::solve(Vector<TConfig> &b, Vector<TConfig> &x,
                << ((m_nrm_ini[i] > eps) ? last_nrm[i] / m_nrm_ini[i] : m_nrm_ini[i])
                << std::fixed;
 
-        ss << endl;
+        ss << std::endl;
         ss << "         Maximum Memory Usage: \t\t" << std::setprecision(3)
            << std::setw(15) << MemoryInfo::getMaxMemoryUsage() << " GB"
            << std::endl;
@@ -945,7 +945,7 @@ AMGX_STATUS Solver<TConfig>::solve(Vector<TConfig> &b, Vector<TConfig> &x,
     if (m_verbosity_level == 2 && getPrintGridStats())
     {
         ss.str(std::string());
-        ss << endl;
+        ss << std::endl;
         amgx_output(ss.str().c_str(), static_cast<int>(ss.str().length()));
         print_grid_stats2();
     }
@@ -954,7 +954,7 @@ AMGX_STATUS Solver<TConfig>::solve(Vector<TConfig> &b, Vector<TConfig> &x,
     if ((m_verbosity_level == 1 || m_verbosity_level == 2) && getPrintGridStats())
     {
         ss.str(std::string());
-        ss << endl;
+        ss << std::endl;
         amgx_output(ss.str().c_str(), static_cast<int>(ss.str().length()));
     }
 
@@ -1032,7 +1032,6 @@ void Solver<TConfig>::print_timings()
 
 using std::scientific;
 using std::fixed;
-using namespace std;
 
 template<class TConfig>
 std::map<std::string, SolverFactory<TConfig>*> &
@@ -1047,12 +1046,12 @@ void SolverFactory<TConfig>::registerFactory(std::string name,
         SolverFactory<TConfig> *f)
 {
     std::map<std::string, SolverFactory<TConfig>*> &factories = getFactories();
-    typename map<string, SolverFactory<TConfig> *>::const_iterator it =
+    typename std::map<std::string, SolverFactory<TConfig> *>::const_iterator it =
         factories.find(name);
 
     if (it != factories.end())
     {
-        string error = "SolverFactory '" + name + "' has already been registered\n";
+        std::string error = "SolverFactory '" + name + "' has already been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -1063,12 +1062,12 @@ template<class TConfig>
 void SolverFactory<TConfig>::unregisterFactory(std::string name)
 {
     std::map<std::string, SolverFactory<TConfig>*> &factories = getFactories();
-    typename map<string, SolverFactory<TConfig> *>::iterator it = factories.find(
+    typename std::map<std::string, SolverFactory<TConfig> *>::iterator it = factories.find(
                 name);
 
     if (it == factories.end())
     {
-        string error = "SolverFactory '" + name + "' has not been registered\n";
+        std::string error = "SolverFactory '" + name + "' has not been registered\n";
         FatalError(error.c_str(), AMGX_ERR_CORE);
     }
 
@@ -1082,7 +1081,7 @@ template<class TConfig>
 void SolverFactory<TConfig>::unregisterFactories()
 {
     std::map<std::string, SolverFactory<TConfig>*> &factories = getFactories();
-    typename map<std::string, SolverFactory<TConfig> *>::iterator it =
+    typename std::map<std::string, SolverFactory<TConfig> *>::iterator it =
         factories.begin();
 
     for (; it != factories.end();)
@@ -1114,17 +1113,17 @@ Solver<TConfig> *SolverFactory<TConfig>::allocate(AMG_Config &cfg,
              solverName == "PCG") &&
             new_scope == "default")
     {
-        string error = "Solver " + solverName
+        std::string error = "Solver " + solverName
                        + " uses an inner solver (i.e. a preconditioner, smoother or coarse_solver) and therefore cannot be used as an inner solver with the default scope due to the possibility of an infinite number of nested solvers. Please use config_version=2, and specify a new scope name for the inner solver. For example: preconditioner(amg_solver) = AMG. \n";
         FatalError( error.c_str(), AMGX_ERR_BAD_PARAMETERS);
     }
 
-    typename map<std::string, SolverFactory<TConfig> *>::const_iterator it =
+    typename std::map<std::string, SolverFactory<TConfig> *>::const_iterator it =
         factories.find(solverName);
 
     if (it == factories.end())
     {
-        string error = "SolverFactory '" + solverName
+        std::string error = "SolverFactory '" + solverName
                        + "' has not been registered\n";
         FatalError( error.c_str( ), AMGX_ERR_CORE);
     }

--- a/src/tests/matrix_coloring_test.cu
+++ b/src/tests/matrix_coloring_test.cu
@@ -429,7 +429,7 @@ color_matrix_file(const std::string &filename, int max_coloring_level = 3)
 
         if (verbose_output)
         {
-            text_output << setw(28) << coloring_schemes[i] << " : num_colors=" << setw(6) << A_d.getMatrixColoring().getNumColors() << " , runtime= " << setw(8) << std::fixed << setprecision(5) << elapsed_time << " mM(" << mincol << "," << maxcol << ")"; // << std::endl;;
+            text_output << std::setw(28) << coloring_schemes[i] << " : num_colors=" << std::setw(6) << A_d.getMatrixColoring().getNumColors() << " , runtime= " << std::setw(8) << std::fixed << std::setprecision(5) << elapsed_time << " mM(" << mincol << "," << maxcol << ")"; // << std::endl;;
         }
 
         if (num_bad == 0 && num_uncolored == 0)
@@ -530,9 +530,9 @@ color_matrix_file(const std::string &filename, int max_coloring_level = 3)
             }
 
             std::string name = coloring_schemes[i];
-            std::cout << setw(80) << coloring_schemes[i];
-            std::cout << " runtime=" << setw(8) << std::fixed << setprecision(5) << total_runtime[name];
-            std::cout << " inefficiency=" << setw(6) << std::fixed << setprecision(3) << coloring_score[name] / coloring_runs[name]; // << std::endl;;
+            std::cout << std::setw(80) << coloring_schemes[i];
+            std::cout << " runtime=" << std::setw(8) << std::fixed << std::setprecision(5) << total_runtime[name];
+            std::cout << " inefficiency=" << std::setw(6) << std::fixed << std::setprecision(3) << coloring_score[name] / coloring_runs[name]; // << std::endl;;
             std::cout << "\n";
         }
 

--- a/src/tests/scalar_smoother_poisson.cu
+++ b/src/tests/scalar_smoother_poisson.cu
@@ -42,9 +42,9 @@ namespace amgx
 // parameter is used as test name
 DECLARE_UNITTEST_BEGIN(ScalarSmootherPoisson);
 
-void check_scalar_smoothers_poisson(int points, int nx, int ny, int nz, string smoother_string, ValueTypeB final_residual_tolerance, int n_smoothing_steps, bool diag_comparison)
+void check_scalar_smoothers_poisson(int points, int nx, int ny, int nz, std::string smoother_string, ValueTypeB final_residual_tolerance, int n_smoothing_steps, bool diag_comparison)
 {
-    string error_string;
+    std::string error_string;
     typedef TemplateConfig<AMGX_host, TConfig::vecPrec, TConfig::matPrec, TConfig::indPrec> TConfig_h;
     typedef Matrix<TConfig_h> Matrix_h;
     typedef Matrix<TConfig> Matrix_hd;

--- a/src/tests/smoother_block_poisson.cu
+++ b/src/tests/smoother_block_poisson.cu
@@ -44,9 +44,9 @@ namespace amgx
 // parameter is used as test name
 DECLARE_UNITTEST_BEGIN(SmootherBlockPoissonTest);
 
-void check_block_smoothers_poisson(int bsize, int points, int nx, int ny, int nz, string smoother_string, ValueTypeB final_residual_tolerance, int n_smoothing_steps, bool diag)
+void check_block_smoothers_poisson(int bsize, int points, int nx, int ny, int nz, std::string smoother_string, ValueTypeB final_residual_tolerance, int n_smoothing_steps, bool diag)
 {
-    string error_string;
+    std::string error_string;
     typedef TemplateConfig<AMGX_host, TConfig::vecPrec, TConfig::matPrec, TConfig::indPrec> TConfig_h;
     typedef Matrix<TConfig_h> Matrix_h;
     typedef Matrix<TConfig> Matrix_hd;
@@ -96,7 +96,7 @@ void check_block_smoothers_poisson(int bsize, int points, int nx, int ny, int nz
     x_ini_hd = scalarx;
     // Set parameters
     AMG_Config cfg;
-    string parameter_string = "solver=" + smoother_string + ", determinism_flag=1, coloring_level=1, matrix_coloring_scheme=MIN_MAX, max_uncolored_percentage=0.15";
+    std::string parameter_string = "solver=" + smoother_string + ", determinism_flag=1, coloring_level=1, matrix_coloring_scheme=MIN_MAX, max_uncolored_percentage=0.15";
     cfg.parseParameterString(const_cast<char *>(parameter_string.c_str()));
     const std::string &cfg_scope = "default";
     // Color the matrix
@@ -134,9 +134,9 @@ void check_block_smoothers_poisson(int bsize, int points, int nx, int ny, int nz
 //  MatrixIO<TConfig>::writeSystemMatrixMarket("A.mtx",A,x_fin_hd);
 //  MatrixIO<TConfig>::writeSystemMatrixMarket("sA.mtx",scalarA,x_ini_hd);
     // assert that result is the same
-    ostringstream os;
+    std::ostringstream os;
     os << bsize;
-    string ssize = os.str();
+    std::string ssize = os.str();
     error_string = "Difference between scalar and block " + ssize + "x" + ssize + " smoother = " + smoother_string;
     UNITTEST_ASSERT_EQUAL_TOL_DESC(error_string.c_str(), x_fin_hd, x_ini_hd, final_residual_tolerance);
     delete scalar_smoother;

--- a/src/tests/zero_in_diagonal_handling.cu
+++ b/src/tests/zero_in_diagonal_handling.cu
@@ -271,7 +271,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
 
     while (!aggregation::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0) || (m_name.compare("PARALLEL_GREEDY_SELECTOR") == 0))
         {
@@ -323,7 +323,7 @@ void test_matrix_coloring(Matrix<T_Config> &A, AMG_Config &cfg, const std::strin
 }
 
 template<class TConfig>
-bool check_solver_mode_pair(string solver)
+bool check_solver_mode_pair(std::string solver)
 {
     return (solver != "FIXCOLOR_GS" &&
             solver != "AMG" &&
@@ -549,7 +549,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
 
     while (!classical::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0))
         {

--- a/src/tests/zero_off_diagonal_handling.cu
+++ b/src/tests/zero_off_diagonal_handling.cu
@@ -153,7 +153,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
 
     while (!aggregation::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0) || (m_name.compare("PARALLEL_GREEDY_SELECTOR") == 0))
         {
@@ -397,7 +397,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
     while (!classical::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
         selector = NULL;
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0))
         {

--- a/src/tests/zero_values_handling.cu
+++ b/src/tests/zero_values_handling.cu
@@ -158,7 +158,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
 
     while (!aggregation::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         //printf("Trying selector %s\n", m_name.c_str());fflush(stdout);
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0) || (m_name.compare("PARALLEL_GREEDY_SELECTOR") == 0))
@@ -214,7 +214,7 @@ void test_matrix_coloring(Matrix<T_Config> &A, AMG_Config &cfg, const std::strin
 }
 
 template<class TConfig>
-bool check_solver_mode_pair(string solver)
+bool check_solver_mode_pair(std::string solver)
 {
     // skip IDR solvers because they don't handle diag zeros well
     return ((solver != "FIXCOLOR_GS") &&
@@ -443,7 +443,7 @@ void test_selectors(Matrix<T_Config> &A, AMG_Config &cfg, const std::string &cfg
 
     while (!classical::SelectorFactory<T_Config>::isIteratorLast(iter))
     {
-        string m_name = iter->first.c_str();
+        std::string m_name = iter->first.c_str();
 
         if ((m_name.compare("GEO") == 0) || (m_name.compare("GEO_ONE_PHASE_HANDSHAKING") == 0))
         {


### PR DESCRIPTION
We have some use of "using namespace std;" throughout. This patch addresses that inconsistency.