### PR TITLE
Change CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,12 @@ project (AMG LANGUAGES C CXX CUDA)
 
 find_package(MPI)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
 
 #disable in-place builds
-if(${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+if(${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   MESSAGE(FATAL_ERROR "Error:  In-place builds are not supported. Please create a separate build directory")
-endif(${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+endif(${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 
 # declare the supported configurations
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;Profile;RelWithTraces" CACHE STRING "Avaialble Configuration Types" FORCE)
@@ -126,7 +126,7 @@ set(AMGX_INCLUDE_EXTERNAL True CACHE BOOL "Include external 3rd party libraries"
 if (AMGX_INCLUDE_EXTERNAL)
   set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DRAPIDJSON_DEFINED)
   set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DRAPIDJSON_DEFINED)
-  include_directories("${CMAKE_SOURCE_DIR}/external/rapidjson/include")
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/external/rapidjson/include")
 endif (AMGX_INCLUDE_EXTERNAL)
 
 set(CMAKE_NO_MPI false CACHE BOOL "Force non-MPI build")
@@ -298,7 +298,7 @@ install(FILES
 install(TARGETS amgx   DESTINATION "lib")
 install(TARGETS amgxsh DESTINATION "lib")
 
-#export(TARGETS amgxsh FILE ${CMAKE_SOURCE_DIR}/amgxsh.cmake)
+#export(TARGETS amgxsh FILE ${CMAKE_CURRENT_SOURCE_DIR}/amgxsh.cmake)
 
 # build examples
 add_subdirectory(examples)


### PR DESCRIPTION
It was reported in #147 that fixing CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR would help with cases where AmgX is a subproject. Apologies this took so long to get to.

I was able to reproduce the problem and the suggested fix works.