### PR TITLE
Increasing thrust version to 2.1.0.

### DIFF
--- a/src/aggregation/selectors/size2_selector.cu
+++ b/src/aggregation/selectors/size2_selector.cu
@@ -713,7 +713,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         matchEdges <<< num_blocks, threads_per_block>>>(num_rows, aggregates_ptr, strongest_neighbour_ptr);
         cudaCheckError();
         numUnassigned_previous = numUnassigned;
-        numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_rows, -1);
+        numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_rows, -1);
         cudaCheckError();
         icount++;
     }
@@ -727,7 +727,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             mergeWithExistingAggregatesCsr <<< num_blocks, threads_per_block>>>(A_row_offsets_ptr, A_column_indices_ptr, A_values_ptr,
                     diag_ptr, num_rows, aggregates_ptr, this->deterministic, (IndexType *) NULL);
             cudaCheckError();
-            numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_rows, -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_rows, -1);
             cudaCheckError();
         };
     }
@@ -742,7 +742,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             // Sync here
             joinExistingAggregates <<< num_blocks, threads_per_block>>>(num_rows, aggregates_ptr, aggregates_candidate.raw());
             cudaCheckError();
-            numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_rows, -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_rows, -1);
             cudaCheckError();
         };
 
@@ -849,7 +849,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
 #else
             cudaStreamSynchronize(str);
             numUnassigned_previous = numUnassigned;
-            numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
             cudaCheckError();
 #endif
             icount++;
@@ -869,7 +869,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             {
                 mergeWithExistingAggregatesBlockDiaCsr_V2 <<< num_blocks, threads_per_block, 0, str>>>(A_row_offsets_ptr, A_column_indices_ptr, edge_weights_ptr, num_block_rows, aggregates_ptr, A.get_block_dimy(), this->deterministic, (IndexType *) NULL);
                 cudaCheckError();
-                numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
+                numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
                 cudaCheckError();
             }
         }
@@ -883,7 +883,7 @@ void Size2Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
                 cudaCheckError();
                 joinExistingAggregates <<< num_blocks, threads_per_block, 0, str>>>(num_block_rows, aggregates_ptr, aggregates_candidate.raw());
                 cudaCheckError();
-                numUnassigned = (int)amgx::thrust::count(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
+                numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregates.begin(), aggregates.begin() + num_block_rows, -1);
                 cudaCheckError();
             }
 

--- a/src/aggregation/selectors/size4_selector.cu
+++ b/src/aggregation/selectors/size4_selector.cu
@@ -179,7 +179,7 @@ void Size4Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         matchEdges <<< num_blocks, threads_per_block>>>(num_block_rows, partner_index_ptr, aggregates_ptr, strongest_neighbour_ptr);
         cudaCheckError();
         numUnassigned_previous = numUnassigned;
-        numUnassigned = (int)amgx::thrust::count(partner_index.begin(), partner_index.end(), -1);
+        numUnassigned = (int)thrust_wrapper::count<AMGX_device>(partner_index.begin(), partner_index.end(), -1);
         cudaCheckError();
         icount++;
     }
@@ -210,7 +210,7 @@ void Size4Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         matchAggregates <IndexType> <<< num_blocks, threads_per_block>>>(aggregates_ptr, aggregated_ptr, strongest_neighbour_ptr, num_block_rows);
         cudaCheckError();
         numUnassigned_previous = numUnassigned;
-        numUnassigned = amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+        numUnassigned = thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
         cudaCheckError();
         icount++;
     }
@@ -224,7 +224,7 @@ void Size4Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         {
             mergeWithExistingAggregatesBlockDiaCsr <<< num_blocks, threads_per_block>>>(A_row_offsets_ptr, A_column_indices_ptr, edge_weights_ptr, num_block_rows, aggregates_ptr, aggregated_ptr, this->deterministic, (IndexType *) NULL);
             cudaCheckError();
-            numUnassigned = (int)amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
             cudaCheckError();
         };
     }
@@ -238,7 +238,7 @@ void Size4Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             cudaCheckError();
             joinExistingAggregates <<< num_blocks, threads_per_block>>>(num_block_rows, aggregates_ptr, aggregated_ptr, aggregates_candidate.raw());
             cudaCheckError();
-            numUnassigned = (int)amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
             cudaCheckError();
         };
     }

--- a/src/aggregation/selectors/size8_selector.cu
+++ b/src/aggregation/selectors/size8_selector.cu
@@ -707,7 +707,7 @@ void Size8Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         {
             matchEdges <<< num_blocks, threads_per_block, 0, stream>>>(num_block_rows, partner_index_ptr, aggregates_ptr, strongest_neighbour_ptr);
             cudaCheckError();
-            numUnassigned = (int)amgx::thrust::count(partner_index.begin(), partner_index.begin() + num_block_rows, -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(partner_index.begin(), partner_index.begin() + num_block_rows, -1);
             cudaCheckError();
         }
         else
@@ -767,7 +767,7 @@ void Size8Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         if (avoid_thrust_count == 0)
         {
             matchAggregatesSize4 <IndexType> <<< num_blocks, threads_per_block, 0, stream>>>(aggregates_ptr, aggregated_ptr, strongest_neighbour_ptr, partner_index_ptr, num_block_rows);
-            numUnassigned = amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+            numUnassigned = thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
         }
         else
         {
@@ -840,7 +840,7 @@ void Size8Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
         if (avoid_thrust_count == 0)
         {
             matchAggregates <IndexType> <<< num_blocks, threads_per_block, 0, stream>>>(aggregates_ptr, aggregated_ptr, strongest_neighbour_ptr, num_block_rows);
-            numUnassigned = amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+            numUnassigned = thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
         }
         else
         {
@@ -863,7 +863,7 @@ void Size8Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             mergeWithExistingAggregatesBlockDiaCsr <<< num_blocks, threads_per_block, 0, stream>>>(A_row_offsets_ptr, A_column_indices_ptr, edge_weights_ptr, num_block_rows, aggregates_ptr, aggregated_ptr, this->deterministic, (IndexType *) NULL, local_iter > 1);
             cudaCheckError();
             numUnassigned_previous = numUnassigned;
-            numUnassigned = (int)amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+            numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
             cudaCheckError();
             local_iter++;
         }
@@ -882,7 +882,7 @@ void Size8Selector<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> 
             if (avoid_thrust_count == 0)
             {
                 joinExistingAggregates <<< num_blocks, threads_per_block, 0, stream>>>(num_block_rows, aggregates_ptr, aggregated_ptr, aggregates_candidate.raw());
-                numUnassigned = (int)amgx::thrust::count(aggregated.begin(), aggregated.end(), -1);
+                numUnassigned = (int)thrust_wrapper::count<AMGX_device>(aggregated.begin(), aggregated.end(), -1);
             }
             else
             {


### PR DESCRIPTION
* Increasing thrust version to 2.1.0.
* Fixing some instances of `count` inside aggregation setup that were calling `cudaMalloc` due to using unwrapped thrust.