### PR TITLE
Change to cuSPARSE SpMV algorithm choice

### DIFF
--- a/src/amgx_cusparse.cu
+++ b/src/amgx_cusparse.cu
@@ -1101,7 +1101,7 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
                               const_cast<MatType*>(vals), CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_BASE_ZERO, matType));
 
         size_t bufferSize = 0;
-        cusparseCheckError(cusparseSpMV_bufferSize(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG2, &bufferSize));
+        cusparseCheckError(cusparseSpMV_bufferSize(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG1, &bufferSize));
 
         void* dBuffer = NULL;
         if(bufferSize > 0)
@@ -1109,7 +1109,7 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
             amgx::memory::cudaMalloc(&dBuffer, bufferSize);
         }
 
-        cusparseCheckError(cusparseSpMV(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG2, dBuffer) );
+        cusparseCheckError(cusparseSpMV(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG1, dBuffer) );
 
         cusparseCheckError(cusparseDestroySpMat(matA_descr));
         cusparseCheckError(cusparseDestroyDnVec(vecX_descr));


### PR DESCRIPTION
CUSPARSE_CSRMV_ALG1 is now significantly higher performance in some cases, so moving to that as default.