### PR TITLE
Changed legacy mem pool back to default

### DIFF
--- a/examples/amgx_mpi_capi_agg.c
+++ b/examples/amgx_mpi_capi_agg.c
@@ -556,7 +556,7 @@ int main(int argc, char **argv)
 
     /* example of how to get (the local part of) the solution */
     //if ((pidx = findParamIndex(argv, argc, "-gpu")) != -1) {
-    //    CUDA_SAFE_CALL(cudaMalloc(&d_result, n*block_dimx*sizeof_v_val));
+    //    CUDA_SAFE_CALL(cudaMallocAsync(&d_result, n*block_dimx*sizeof_v_val));
     //    AMGX_vector_download(x, d_result);
     //    CUDA_SAFE_CALL(cudaFree(d_result));
     //}

--- a/include/cutil.h
+++ b/include/cutil.h
@@ -315,7 +315,7 @@ template <class ScalarType> bool containsNan( ScalarType *mem, int num )
 
     if (num > 0)
     {
-        amgx::memory::cudaMalloc((void**)&d_retval, sizeof(bool));
+        amgx::memory::cudaMallocAsync((void**)&d_retval, sizeof(bool));
         cudaMemcpy(d_retval, &retval, sizeof(bool), cudaMemcpyHostToDevice);
         containsNan_kernel <<< blocks, threads>>>(mem, num, d_retval);
         cudaCheckError();

--- a/include/energymin/interpolators/common.h
+++ b/include/energymin/interpolators/common.h
@@ -69,7 +69,7 @@ void allocMem(DataType *&ptr,
     cudaCheckError();
     size_t sz = numEntry * sizeof(DataType);
     if(sz == 0) { return; }
-    amgx::memory::cudaMalloc((void **)&ptr, sz);
+    amgx::memory::cudaMallocAsync((void **)&ptr, sz);
     cudaCheckError();
 
     if (initToZero)

--- a/include/global_thread_handle.h
+++ b/include/global_thread_handle.h
@@ -141,7 +141,7 @@ class MemoryPool
         //Mutex added to fix ICE threadsafe issue
         std::mutex m_mutex2;
 
-#ifndef USE_LEGACY_MEMPOOL
+#ifndef USE_CUDAMALLOCASYNC
         cudaMemPool_t m_mem_pool;
 #endif
 
@@ -231,8 +231,8 @@ void cudaHostRegister(void *ptr, int size);
 cudaError_t cudaMallocHost(void **ptr, size_t size);
 cudaError_t cudaFreeHost(void *ptr);
 
-cudaError_t cudaMalloc(void **ptr, size_t size);
-cudaError_t cudaFreeAsync(void *ptr);
+cudaError_t cudaMallocAsync(void **ptr, size_t size, cudaStream_t stream = 0);
+cudaError_t cudaFreeAsync(void *ptr, cudaStream_t stream = 0);
 
 // Wait for the asynchronous frees to complete.
 void cudaFreeWait();

--- a/include/strided_reduction.h
+++ b/include/strided_reduction.h
@@ -665,7 +665,8 @@ void launch_strided_reduction(scalar_out *out_host, const scalar_t *in_d, const 
     const int n_blocks = std::min(  (long long int) 13 * 2, (N - 1) / (n_items_per_thread * cta_size) + 1   ); //just one wave of blocks
     const int out_size = n_blocks * STRIDE;
     scalar_out *out_d = 0;
-    amgx::memory::cudaMalloc((void **) &out_d, out_size * sizeof(scalar_out));
+    amgx::memory::cudaMallocAsync((void **) &out_d, out_size * sizeof(scalar_out));
+    cudaCheckError();
     cudaMemset(out_d, 0, out_size * sizeof(scalar_out));
     cudaFuncSetCacheConfig(strided_reduction<STRIDE, cta_size, 32, 16, op_sum, scalar_t, scalar_out, TRANSFORM>, cudaFuncCachePreferL1);
     strided_reduction<STRIDE, cta_size, 32, 16, op_sum, scalar_t, scalar_out, TRANSFORM> <<< n_blocks, cta_size, 0, amgx::thrust::global_thread_handle::get_stream()>>>(in_d, N, out_d, tx);

--- a/include/vector_thrust_allocator.h
+++ b/include/vector_thrust_allocator.h
@@ -124,7 +124,7 @@ class thrust_amgx_allocator<T, AMGX_device>
                                 const_pointer = const_pointer(static_cast<T *>(0)))
         {
             void *ptr;
-            amgx::memory::cudaMalloc(&ptr, sizeof(T)*cnt);
+            amgx::memory::cudaMallocAsync(&ptr, sizeof(T)*cnt);
             return pointer((T *)ptr);
         } // end allocate()
 

--- a/src/amgx_cusparse.cu
+++ b/src/amgx_cusparse.cu
@@ -1106,7 +1106,7 @@ inline void generic_SpMV(cusparseHandle_t handle, cusparseOperation_t trans,
         void* dBuffer = NULL;
         if(bufferSize > 0)
         {
-            amgx::memory::cudaMalloc(&dBuffer, bufferSize);
+            amgx::memory::cudaMallocAsync(&dBuffer, bufferSize, stream);
         }
 
         cusparseCheckError(cusparseSpMV(handle, trans, alpha, matA_descr, vecX_descr, beta, vecY_descr, matType, CUSPARSE_CSRMV_ALG1, dBuffer) );
@@ -1644,7 +1644,7 @@ generic_SpMM(cusparseHandle_t handle, cusparseOperation_t transA,
     void* dBuffer = NULL;
     if(bufferSize > 0)
     {
-        amgx::memory::cudaMalloc(&dBuffer, bufferSize);
+        amgx::memory::cudaMallocAsync(&dBuffer, bufferSize);
     }
 
     // Compute the sparse matrix - dense matrix product
@@ -1798,7 +1798,7 @@ void transpose_internal(cusparseHandle_t handle, int nRows, int nCols, int nNz, 
     void *buffer = nullptr;
     if (bufferSize > 0)
     {
-        amgx::memory::cudaMalloc(&buffer, bufferSize);
+        amgx::memory::cudaMallocAsync(&buffer, bufferSize);
     }
 
     cusparseCheckError(cusparseCsr2cscEx2(

--- a/src/amgx_lapack.cu
+++ b/src/amgx_lapack.cu
@@ -1014,7 +1014,7 @@ void gpu_geqrf(int m, int n, T *a, int lda,
 {
     int k = std::min(m, n);
     T *aii;
-    amgx::memory::cudaMalloc((void**)&aii, sizeof(T));
+    amgx::memory::cudaMallocAsync((void**)&aii, sizeof(T));
 
     for (int i = 0; i < k; ++i)
     {

--- a/src/csr_multiply.cu
+++ b/src/csr_multiply.cu
@@ -452,7 +452,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
                                   computeType, CUSPARSE_SPGEMM_DEFAULT,
                                   spgemmDesc, &bufferSize1, NULL);
     if(bufferSize1 > 0) {
-        amgx::memory::cudaMalloc(&dBuffer1, bufferSize1);
+        amgx::memory::cudaMallocAsync(&dBuffer1, bufferSize1);
     }
     // inspect the matrices A and B to understand the memory requiremnent for
     // the next step
@@ -467,7 +467,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
                            computeType, CUSPARSE_SPGEMM_DEFAULT,
                            spgemmDesc, &bufferSize2, NULL);
     if(bufferSize2 > 0) {
-        amgx::memory::cudaMalloc(&dBuffer2, bufferSize2);
+        amgx::memory::cudaMallocAsync(&dBuffer2, bufferSize2);
     }
 
     // compute the intermediate product of A * B
@@ -545,7 +545,7 @@ template< AMGX_VecPrecision V, AMGX_MatPrecision M, AMGX_IndPrecision I > void C
             info, &pBufferSizeInBytes));
 
     // Allocate the intermediary buffer
-    amgx::memory::cudaMalloc(&pBuffer, pBufferSizeInBytes);
+    amgx::memory::cudaMallocAsync(&pBuffer, pBufferSizeInBytes);
 
     int nnzC;
     int *nnzTotalDevHostPtr = &nnzC;

--- a/src/distributed/distributed_manager.cu
+++ b/src/distributed/distributed_manager.cu
@@ -2079,7 +2079,7 @@ void *DistributedManagerBase<TConfig>::getDevicePointerForData(void *ptr, size_t
     else
     {
         // Received unregistered or host allocated data (malloc)
-        rc = amgx::memory::cudaMalloc(&ptr_d, size);
+        rc = amgx::memory::cudaMallocAsync(&ptr_d, size);
 
         if (rc != cudaSuccess)
         {
@@ -2110,7 +2110,7 @@ void *DistributedManagerBase<TConfig>::getDevicePointerForData(void *ptr, size_t
         if (rc != cudaSuccess)
         {
             //you are in case 1
-            rc = amgx::memory::cudaMalloc(&ptr_d, size);
+            rc = amgx::memory::cudaMallocAsync(&ptr_d, size);
 
             if (rc != cudaSuccess)
             {
@@ -2200,7 +2200,7 @@ const void *DistributedManagerBase<TConfig>::getDevicePointerForData(const void 
     else
     {
         // Received unregistered or host allocated data (malloc)
-        rc = amgx::memory::cudaMalloc(&ptr_d, size);
+        rc = amgx::memory::cudaMallocAsync(&ptr_d, size);
 
         if (rc != cudaSuccess)
         {
@@ -2231,7 +2231,7 @@ const void *DistributedManagerBase<TConfig>::getDevicePointerForData(const void 
         if (rc != cudaSuccess)
         {
             //you are in case 1
-            rc = amgx::memory::cudaMalloc(&ptr_d, size);
+            rc = amgx::memory::cudaMallocAsync(&ptr_d, size);
 
             if (rc != cudaSuccess)
             {

--- a/src/global_thread_handle.cu
+++ b/src/global_thread_handle.cu
@@ -83,7 +83,7 @@ MemoryPool::MemoryPool(size_t max_block_size, size_t page_size, size_t max_size)
 {
     //initializeCriticalSection(&m_mutex2);
 
-#ifndef USE_LEGACY_MEMPOOL
+#ifndef USE_CUDAMALLOCASYNC
     int device;
     cudaGetDevice(&device);
     cudaDeviceGetMemPool(&m_mem_pool, device);
@@ -844,14 +844,11 @@ cudaError_t cudaFreeHost(void *ptr)
     return error;
 }
 
-cudaError_t cudaMalloc(void **ptr, size_t size)
+cudaError_t cudaMallocAsync(void **ptr, size_t size, cudaStream_t stream)
 {
-#ifndef USE_LEGACY_MEMPOOL
+#ifndef USE_CUDAMALLOCASYNC
 
-    cudaError_t e = ::cudaMallocAsync(ptr, size, getStream());
-    if(e != cudaSuccess) { return e; }
-
-    return cudaStreamSynchronize(0);
+    return ::cudaMallocAsync(ptr, size, stream);
 
 #else
 
@@ -962,11 +959,11 @@ cudaError_t cudaMalloc(void **ptr, size_t size)
 #endif
 }
 
-cudaError_t cudaFreeAsync(void *ptr)
+cudaError_t cudaFreeAsync(void *ptr, cudaStream_t stream)
 {
-#ifndef USE_LEGACY_MEMPOOL
+#ifndef USE_CUDAMALLOCASYNC
 
-    return ::cudaFreeAsync(ptr, getStream());
+    return ::cudaFreeAsync(ptr, stream);
 
 #else
 

--- a/src/hash_workspace.cu
+++ b/src/hash_workspace.cu
@@ -27,6 +27,7 @@
 
 #include <hash_workspace.h>
 #include <global_thread_handle.h>
+#include <error.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -46,9 +47,13 @@ Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::Hash_Workspace(
     m_keys(NULL),
     m_vals(NULL)
 {
-    amgx::memory::cudaMalloc( (void **) &m_status, sizeof(int) );
-    amgx::memory::cudaMalloc( (void **) &m_work_queue, sizeof(int) );
+    amgx::memory::cudaMallocAsync( (void **) &m_status, sizeof(int) );
+    cudaCheckError();
+    amgx::memory::cudaMallocAsync( (void **) &m_work_queue, sizeof(int) );
+    cudaCheckError();
     allocate_workspace();
+    cudaStreamSynchronize(0);
+    cudaCheckError();
 }
 
 // ====================================================================================================================
@@ -80,7 +85,7 @@ void Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::allocate_w
     }
 
     size_t sz = NUM_WARPS_IN_GRID * m_gmem_size * sizeof(Key_type);
-    amgx::memory::cudaMalloc( (void **) &m_keys, sz );
+    amgx::memory::cudaMallocAsync( (void **) &m_keys, sz );
 
     // Skip value allocation if needed.
     if ( !m_allocate_vals )
@@ -95,7 +100,7 @@ void Hash_Workspace<TemplateConfig<AMGX_device, V, M, I>, Key_type >::allocate_w
     }
 
     sz = NUM_WARPS_IN_GRID * m_gmem_size * sizeof(double);
-    amgx::memory::cudaMalloc( (void **) &m_vals, sz );
+    amgx::memory::cudaMallocAsync( (void **) &m_vals, sz );
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/scalers/diagonal_symmetric.cu
+++ b/src/scalers/diagonal_symmetric.cu
@@ -138,7 +138,7 @@ void DiagonalSymmetricScaler<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t
     grabDiagonalVector <<< 4096, 128>>>(A.get_num_rows(), A.row_offsets.raw(), A.col_indices.raw(), A.values.raw(), diag.raw());
     // check diagonal +ve
     bool positive = true, *d_positive;
-    amgx::memory::cudaMalloc((void**)&d_positive, sizeof(bool));
+    amgx::memory::cudaMallocAsync((void**)&d_positive, sizeof(bool));
     cudaMemcpy(d_positive, &positive, sizeof(bool), cudaMemcpyHostToDevice);
     checkPositiveVector <<< 4096, 256>>>(diag.size(), diag.raw(), d_positive);
     cudaMemcpy(&positive, d_positive, sizeof(bool), cudaMemcpyDeviceToHost);

--- a/src/solvers/dense_lu_solver.cu
+++ b/src/solvers/dense_lu_solver.cu
@@ -625,10 +625,10 @@ allocMem(DataType *&ptr,
          bool initToZero)
 {
     if ( ptr != NULL ) { amgx::memory::cudaFreeAsync(ptr); }
-
     cudaCheckError();
+
     size_t sz = numEntry * sizeof(DataType);
-    amgx::memory::cudaMalloc((void **)&ptr, sz);
+    amgx::memory::cudaMallocAsync((void **)&ptr, sz);
     cudaCheckError();
 
     if (initToZero)


### PR DESCRIPTION
Likely legacy mem pool will stay default for a single release.

To enable new memory management, define `USE_CUDAMALLOCASYNC`.