### PR TITLE
Fixes MSVC build: Find OpenMP before adding /Zl to compiler flags, and link amgx_tests_launcher with amgx_tests_library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ cmake_minimum_required (VERSION 3.18)
 project (AMG LANGUAGES C CXX CUDA)
 
 find_package(MPI)
+find_package(OpenMP)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,9 +107,7 @@ ELSE()
     set(libs_all CUDA::cusparse CUDA::cublas rt dl)
 ENDIF()
 
-add_dependencies(amgx_tests_launcher amgx_tests_library)
-
-target_link_libraries(amgx_tests_launcher amgxsh ${libs_all} OpenMP::OpenMP_C)
+target_link_libraries(amgx_tests_launcher amgx_tests_library amgxsh ${libs_all} OpenMP::OpenMP_C)
 
 if(MPI_FOUND)
     target_link_libraries(amgx_tests_launcher MPI::MPI_CXX)


### PR DESCRIPTION
Hi AmgX team! This merge request fixes two build issues I had when compiling for Windows using Visual Studio 2022, this command line, and a clean CMake cache:

```
mkdir build && cd build
cmake -DCUDA_ARCH="80" ..
cmake --build . -j
```

* CMake reported that it couldn't find OpenMP, since its test compilations were failing. It turns out this was because CMakeLists.txt added `/Zl` to the Debug and MinSizeRel command lines before including Thrust, which would find OpenMP: it seems `/Zl` removes the information MSVC looks at to automatically link with OpenMP, linking fails because of that, and CMake fails. This merge request's fix is to call `find_package(OpenMP)` near the start where `MPI` is found; then CMake's test compilations succeed and it successfully finds OpenMP.

* Building `amgx_tests_launcher` produces some unresolved symbol errors. I implemented the fix from wanjunling in https://github.com/NVIDIA/AMGX/issues/249#issuecomment-1652879283, except I linked with `amgx_tests_library` (which in turn links with `amgx`) instead of `amgx`. This also lets me remove an `add_dependency()` line, since CMake's `target_link_libraries` automatically adds dependencies.

Thanks!