### PR TITLE
Adding test for support to cudaMallocAsync path

### DIFF
--- a/include/global_thread_handle.h
+++ b/include/global_thread_handle.h
@@ -141,10 +141,6 @@ class MemoryPool
         //Mutex added to fix ICE threadsafe issue
         std::mutex m_mutex2;
 
-#ifdef USE_CUDAMALLOCASYNC
-        cudaMemPool_t m_mem_pool;
-#endif
-
     private:
         // No copy.
         MemoryPool(const MemoryPool &);


### PR DESCRIPTION
Double checks that the target device actually supports cudaMallocAsync.