### PR TITLE
Removing the lonely #include <omp.h>, which seems to be not in use

### DIFF
--- a/src/aggregation/selectors/multi_pairwise.cu
+++ b/src/aggregation/selectors/multi_pairwise.cu
@@ -48,8 +48,6 @@
 #include <aggregation/coarseAgenerators/thrust_coarse_A_generator.h>
 #include <aggregation/coarseAgenerators/low_deg_coarse_A_generator.h>
 
-#include <omp.h>
-
 #define EXPERIMENTAL_ITERATIVE_MATCHING
 
 namespace amgx


### PR DESCRIPTION
Nobody would ever spot it, but I have luck: it creates a strange compile error on nvcc with -ccbin=clang:

```
/usr/lib/llvm-14/lib/clang/14.0.0/include/omp.h(496): error: function omp_is_initial_device has already been defined
```

Anyway, this include feels like an accidentally committed leftover from some experiment, do I make a good guess?