### PR TITLE
Make shared library, tests and examples optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ cmake_minimum_required (VERSION 3.18)
 # the project
 project (AMG LANGUAGES C CXX CUDA)
 
+option(AMGX_WITH_TESTS "Compile AmgX test executables" ON)
+option(AMGX_WITH_EXAMPLES "Compile AmgX examples" ON)
+
 find_package(MPI)
 find_package(OpenMP)
 
@@ -292,5 +295,7 @@ install(FILES
   DESTINATION include)
 
 # build examples
+if(AMGX_WITH_EXAMPLES)
 add_subdirectory(examples)
+endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,43 +255,41 @@ target_compile_options(amgx_libs PUBLIC $<$<COMPILE_LANGUAGE:CUDA>: ${CUDA_NVCC_
 # build amgx
 add_library(amgx STATIC $<TARGET_OBJECTS:amgx_libs>)  # static lib
 target_link_libraries(amgx amgx_libs)
-
-add_library(amgxsh SHARED $<TARGET_OBJECTS:amgx_libs>)  # shared lib
-target_link_libraries(amgxsh amgx_libs)
-
 set_target_properties(amgx PROPERTIES LINKER_LANGUAGE CUDA)
-set_target_properties(amgxsh PROPERTIES LINKER_LANGUAGE CUDA)
-
 target_compile_options(amgx PUBLIC $<$<COMPILE_LANGUAGE:CUDA>: ${CUDA_NVCC_FLAGS} >)
-target_compile_options(amgxsh PUBLIC $<$<COMPILE_LANGUAGE:CUDA>: ${CUDA_NVCC_FLAGS} >)
-
 IF (WIN32)
   target_link_libraries(amgx CUDA::cublas CUDA::cusparse CUDA::cusolver)
-  target_link_libraries(amgxsh CUDA::cublas CUDA::cusparse CUDA::cusolver)
 ELSE (WIN32)
   target_link_libraries(amgx CUDA::cublas CUDA::cusparse CUDA::cusolver CUDA::nvToolsExt m pthread)
+ENDIF(WIN32)
+if(MPI_FOUND)
+target_link_libraries(amgx MPI::MPI_CXX)
+endif(MPI_FOUND)
+set_target_properties(amgx PROPERTIES CUDA_ARCHITECTURES "${CUDA_ARCH}")
+install(TARGETS amgx DESTINATION "lib")
+
+if(BUILD_SHARED_LIBS)
+add_library(amgxsh SHARED $<TARGET_OBJECTS:amgx_libs>)  # shared lib
+target_link_libraries(amgxsh amgx_libs)
+set_target_properties(amgxsh PROPERTIES LINKER_LANGUAGE CUDA)
+target_compile_options(amgxsh PUBLIC $<$<COMPILE_LANGUAGE:CUDA>: ${CUDA_NVCC_FLAGS} >)
+IF (WIN32)
+  target_link_libraries(amgxsh CUDA::cublas CUDA::cusparse CUDA::cusolver)
+ELSE (WIN32)
   target_link_libraries(amgxsh CUDA::cublas CUDA::cusparse CUDA::cusolver CUDA::nvToolsExt m pthread)
 ENDIF(WIN32)
-
 if(MPI_FOUND)
-    target_link_libraries(amgx   MPI::MPI_CXX)
     target_link_libraries(amgxsh MPI::MPI_CXX)
 endif(MPI_FOUND)
-
-# set arch for main libs
-
-set_target_properties(amgx PROPERTIES CUDA_ARCHITECTURES "${CUDA_ARCH}")
 set_target_properties(amgxsh PROPERTIES CUDA_ARCHITECTURES "${CUDA_ARCH}")
+install(TARGETS amgxsh DESTINATION "lib")
+#export(TARGETS amgxsh FILE ${CMAKE_CURRENT_SOURCE_DIR}/amgxsh.cmake)
+endif(BUILD_SHARED_LIBS)
 
 install(FILES
   include/amgx_config.h
   include/amgx_c.h
   DESTINATION include)
-
-install(TARGETS amgx   DESTINATION "lib")
-install(TARGETS amgxsh DESTINATION "lib")
-
-#export(TARGETS amgxsh FILE ${CMAKE_CURRENT_SOURCE_DIR}/amgxsh.cmake)
 
 # build examples
 add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,13 +6,19 @@ cmake_minimum_required (VERSION 3.18)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../include" "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 
+if(BUILD_SHARED_LIBS)
+set(AMGX_LIB amgxsh)
+else(BUILD_SHARED_LIBS)
+set(AMGX_LIB amgx)
+endif(BUILD_SHARED_LIBS)
+
 GET_FILENAME_COMPONENT(CMAKE_C_COMPILER_NAME "${CMAKE_C_COMPILER}" NAME)
 IF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all CUDA::cusparse CUDA::cusolver)
-  set(dyn_libs amgxsh CUDA::cudart_static CUDA::cublas)
+  set(dyn_libs ${AMGX_LIB} CUDA::cudart_static CUDA::cublas)
 ELSE(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
   set(libs_all CUDA::cusparse CUDA::cusolver rt dl)
-  set(dyn_libs amgxsh rt dl CUDA::cudart_static CUDA::cublas)
+  set(dyn_libs ${AMGX_LIB} rt dl CUDA::cudart_static CUDA::cublas)
 ENDIF(CMAKE_C_COMPILER_NAME MATCHES cl AND NOT CMAKE_C_COMPILER_NAME MATCHES clang)
 
 ADD_EXECUTABLE(amgx_capi amgx_capi.c)
@@ -79,22 +85,22 @@ if(MPI_FOUND)
       SET_SOURCE_FILES_PROPERTIES( amgx_mpi_capi.c PROPERTIES COMPILE_FLAGS -std=c99 )
       set_target_properties ( amgx_mpi_capi PROPERTIES COMPILE_FLAGS "${OpenMP_C_FLAGS} -pthread" )
       set_target_properties ( amgx_mpi_capi PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
-      target_link_libraries(amgx_mpi_capi amgxsh ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
+      target_link_libraries(amgx_mpi_capi ${AMGX_LIB} ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
 
       SET_SOURCE_FILES_PROPERTIES( amgx_mpi_capi_agg.c PROPERTIES COMPILE_FLAGS -std=c99 )
       set_target_properties ( amgx_mpi_capi_agg PROPERTIES COMPILE_FLAGS "${OpenMP_C_FLAGS} -pthread" )
       set_target_properties ( amgx_mpi_capi_agg PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
-      target_link_libraries(amgx_mpi_capi_agg amgxsh ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
+      target_link_libraries(amgx_mpi_capi_agg ${AMGX_LIB} ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
 
       SET_SOURCE_FILES_PROPERTIES( amgx_mpi_capi_cla.c PROPERTIES COMPILE_FLAGS -std=c99 )
       set_target_properties ( amgx_mpi_capi_cla PROPERTIES COMPILE_FLAGS "${OpenMP_C_FLAGS} -pthread" )
       set_target_properties ( amgx_mpi_capi_cla PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
-      target_link_libraries(amgx_mpi_capi_cla amgxsh ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
+      target_link_libraries(amgx_mpi_capi_cla ${AMGX_LIB} ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
 
       SET_SOURCE_FILES_PROPERTIES( amgx_mpi_poisson7.c PROPERTIES COMPILE_FLAGS -std=c99 )
       set_target_properties ( amgx_mpi_poisson7 PROPERTIES COMPILE_FLAGS "${OpenMP_C_FLAGS} -pthread" )
       set_target_properties ( amgx_mpi_poisson7 PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
-      target_link_libraries( amgx_mpi_poisson7 amgxsh ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
+      target_link_libraries( amgx_mpi_poisson7 ${AMGX_LIB} ${omp_lib} ${MPI_C_LIBRARIES} ${dyn_libs})
 
     ENDIF(WIN32) 
     

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ install(FILES
 
 set(AMGX_INCLUDES ../include)
 
+if(AMGX_WITH_TESTS)
 set(tests_all ${tests_all} testframework.cu test_utils.cu unit_test.cu)
 
 add_library(amgx_tests_libs OBJECT ${tests_all})
@@ -101,3 +102,4 @@ if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Release")
   install(TARGETS amgx_tests_launcher DESTINATION "lib/tests")
 endif(NOT ${CMAKE_BUILD_TYPE} MATCHES "Release")
 
+endif(AMGX_WITH_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,11 @@ ELSE()
     set(libs_all CUDA::cusparse CUDA::cublas rt dl)
 ENDIF()
 
+if(BUILD_SHARED_LIBS)
 target_link_libraries(amgx_tests_launcher amgx_tests_library amgxsh ${libs_all} OpenMP::OpenMP_C)
+else(BUILD_SHARED_LIBS)
+target_link_libraries(amgx_tests_launcher amgx ${libs_all} OpenMP::OpenMP_C)
+endif()
 
 if(MPI_FOUND)
     target_link_libraries(amgx_tests_launcher MPI::MPI_CXX)


### PR DESCRIPTION
Make AMGX shared library (amgxsh) building optional for the following good reasons:
    
0. All CMake projects are generally encouraged to support BUILD_SHARED_LIBS option, it is often found in the state-of-art opensource software
1. We want to link AMGX statically, in order to have only what we need in the application binary
2. AMGX shared library throws "relocation truncated to fit" errors upon linking in Debug mode

Furthermore, adding `AMGX_WITH_TESTS` and `AMGX_WITH_EXAMPLES` options to disable examples and tests, e.g. for production builds.

By default, the previous build behavior is preserved.