### PR TITLE
Cleaning up output from config parsing.

### DIFF
--- a/include/amg_config.h
+++ b/include/amg_config.h
@@ -134,9 +134,21 @@ class AMG_Config
 
     public:
         AMG_Config();
+        
+        /****************************************************
+        * Main parse functionality
+        ****************************************************/
+        
+        AMGX_ERROR parseFile(const char *filename);
+
+        AMGX_ERROR parseParameterString(const char *str);
+
+        AMGX_ERROR parseParameterStringAndFile(const char *str, const char *filename);
+
         /***********************************************
          * Registers the parameter in the database.
         **********************************************/
+
         template <typename Type> static void registerParameter(std::string name, std::string description, Type default_value)
         {
             param_desc[name] = ParameterDescription(&typeid(Type), name, description, default_value);
@@ -174,28 +186,11 @@ class AMG_Config
         template <typename Type> Type getParameter(const std::string &name, const std::string &current_scope) const;
         template <typename Type> void getParameter(const std::string &name, Type &value, const std::string &current_scope, std::string &new_scope) const;
 
-        AMGX_ERROR parseParameterString(const char *str);
-
-        AMGX_ERROR parseParameterStringAndFile(const char *str, const char *filename);
-
-        template<typename T>
-        void setNamedParameter(const std::string &name, const T &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter);
-        template<typename T>
-        void importNamedParameter(const char *c_name, const T &c_value, const std::string &current_scope, const std::string &new_scope);
-
-#ifdef RAPIDJSON_DEFINED
-        AMGX_ERROR parse_json_file(const char *filename);
-        AMGX_ERROR parse_json_string(const char *str);
-        void import_json_object(rapidjson::Value &obj, bool outer);
-#endif
-
-        // this will return an error if JSON is not supported
+        /**********************************************
+        * Writes supported parameters and values to the file
+        * This will return an error if JSON is not supported
+        *********************************************/        
         static AMGX_ERROR write_parameters_description_json(const char *filename);
-
-        /****************************************************
-        * Parse a config file
-        ****************************************************/
-        AMGX_ERROR parseFile(const char *filename);
 
         /**********************************************
         * Sets a parameter in the database
@@ -262,6 +257,17 @@ class AMG_Config
         AMGX_ERROR getParameterStringFromFile(const char *filename, std::string &params);
 
         AMGX_ERROR checkString(std::string &str);
+
+        template<typename T>
+        void setNamedParameter(const std::string &name, const T &c_value, const std::string &current_scope, const std::string &new_scope, ParamDesc::iterator &param_desc_iter);
+        template<typename T>
+        void importNamedParameter(const char *c_name, const T &c_value, const std::string &current_scope, const std::string &new_scope);
+
+#ifdef RAPIDJSON_DEFINED
+        AMGX_ERROR parse_json_file(const char *filename);
+        AMGX_ERROR parse_json_string(const char *str);
+        void import_json_object(rapidjson::Value &obj, bool outer);
+#endif
 
         /****************************************************
          * Parse parameters in the format

--- a/src/misc.cu
+++ b/src/misc.cu
@@ -51,7 +51,7 @@ int amgx_printf(const char *fmt, ...)
     va_start(ap, fmt);
     retval = vsnprintf(buffer, PRINT_BUF_SIZE, fmt, ap);
     va_end(ap);
-    amgx_output(buffer, strlen(buffer));
+    amgx_distributed_output(buffer, strlen(buffer));
     return retval;
 }
 

--- a/src/solvers/cheb_solver.cu
+++ b/src/solvers/cheb_solver.cu
@@ -112,11 +112,6 @@ Chebyshev_Solver<T_Config>::Chebyshev_Solver( AMG_Config &cfg, const std::string
                                   "eig_eigenvector=0,\n"
                                   "eig_eigenvector_solver=default";
 
-    /*std::ifstream t("/home/marsaev/work/perforce/marsaev_sw/sw/gpgpu/amgx/amg/eigen_examples/POWER_ITERATION");
-    std::stringstream buffer;
-    buffer << t.rdbuf();
-    std::string eig_cfg_string = buffer.str();*/
-
     if (m_lambda_mode < 2)
     {
         AMG_Configuration eig_cfg;


### PR DESCRIPTION
Minor QOL improvement - clarifying error reports from config parsing output. Main cases:
1) File read error, will print an error like:
```
Error parsing config file: Error: Cannot read config file: file_not_exists.json
```
1) Config is parsable JSON. but error in configuration - stops trying to parse further, prints error like:
```
Variable 'srength_threshold' not registered
Error parsing config file: Error: Cannot import config from JSON file: bad_json.json
```
2) Config cannot be parsed as JSON, tries to parse as a legacy config. In case it errors out, it will print an error like:
```
Error parsing parameter string: Incorrect config entry (number of equal signs is not 1) :  "config_version": 2
Error parsing config file: Error: Can't parse either JSON or legacy config from file: bad_cfg.json
```
