### PR TITLE
DRAFT: AMGX_vector_upload does not use the memory pool

### DIFF
--- a/src/distributed/distributed_manager.cu
+++ b/src/distributed/distributed_manager.cu
@@ -5272,6 +5272,7 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>
 void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indPrec> >::transformVector(VVector_v &v)
 {
+    amgx::memory::setAsyncFreeFlag(true);
     if (this->neighbors.size() == 0) { return; }
     else if (this->renumbering.size() == 0)
     {
@@ -5309,6 +5310,11 @@ void DistributedManager<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_indP
 
     cudaCheckError();
     v.set_transformed();
+    amgx::thrust::global_thread_handle::joinDevicePools();
+    amgx::memory::setAsyncFreeFlag(true);
+
+    // XXX Is this needed?
+    amgx::thrust::global_thread_handle::cudaFreeWait();
 }
 
 template <AMGX_VecPrecision t_vecPrec, AMGX_MatPrecision t_matPrec, AMGX_IndPrecision t_indPrec>


### PR DESCRIPTION
Starting to flesh out how we ensure API calls like AMGX_vector_upload use the memory pool. Not sure why they don't already but this would fix transformVector, enabling better perf for AMGX_vector_upload.