### PR TITLE
Fixing minor issues with block handling

### DIFF
--- a/src/distributed/distributed_arranger.cu
+++ b/src/distributed/distributed_arranger.cu
@@ -2796,7 +2796,7 @@ void DistributedArranger<TemplateConfig<AMGX_device, t_vecPrec, t_matPrec, t_ind
         }
     }
 
-    A.resize(new_num_rows, new_num_rows, new_num_nnz, 1, 1, 1);
+    A.resize(new_num_rows, new_num_rows, new_num_nnz, A.get_block_dimx(), A.get_block_dimy(), 1);
 
     for (int i = 0; i < num_neighbors; i++)
     {

--- a/src/matrix.cu
+++ b/src/matrix.cu
@@ -1201,7 +1201,7 @@ void reorderElementsDeviceCSR(INDEX_TYPE num_rows,
     //TODO: optimise this in terms of storage
     INDEX_TYPE storage_space = 100 * 1024 * 1024 * sizeof(T) / sizeof(cuDoubleComplex); // because we allocate as for cuComplex
     INDEX_TYPE blocks = 1500 < storage_space / (max_row_length * block_size * sizeof(T)) ? 1500 : storage_space / (max_row_length * block_size * sizeof(T));
-    blocks = blocks < num_rows ? blocks : num_rows;
+    blocks = blocks < num_rows ? max(1, blocks) : num_rows;
     INDEX_TYPE aligned_space = ((max_row_length * block_size * sizeof(T) / 128 + 1) * 128) / sizeof(T); //pad to 128 bytes
     Vector<amgx::TemplateConfig<AMGX_device, AMGX_vecDoubleComplex, AMGX_matDoubleComplex, AMGX_indInt> > tempstorage(blocks * aligned_space);
     reorderElements <<< blocks, 256>>>(num_rows, row_offsets, permutation, values, (T *)tempstorage.raw(), aligned_space, block_size);


### PR DESCRIPTION
Fixed two issues with the handling of block sizes > 1.

(1) block sizes were incorrectly resized back to 1 in append_halo_rows
(2) block sizes were incorrectly truncated to 0 when enabling MULTICOLOR_ILU