### PR TITLE
Zero-Copy Interface

### DIFF
--- a/include/amgx_c.h
+++ b/include/amgx_c.h
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2011 - 2024 NVIDIA CORPORATION. All Rights Reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// SPDX-FileCopyrightText: Portions Copyright 2024 Siemens and/or its affiliates
+//
+// November 2024 modified by Siemens and/or its affiliates by adding zero-copy interface
 
 #ifndef __AMGX_C_H_INCLUDE__
 #define __AMGX_C_H_INCLUDE__
@@ -100,6 +104,16 @@ typedef enum
 } AMGX_DIST_PARTITION_INFO;
 
 /*********************************************************
+ * Flags for the zero-copy interface
+ *********************************************************/
+typedef enum
+{
+    AMGX_MATRIX_ROW_OFFSETS = 0,
+    AMGX_MATRIX_COL_INDICES = 1,
+    AMGX_MATRIX_VALUES      = 2
+} AMGX_MATRIX_DATA_VECTOR;
+
+/*********************************************************
  * Forward (opaque) handle declaration
  *********************************************************/
 typedef void (*AMGX_print_callback)(const char *msg, int length);
@@ -188,6 +202,12 @@ AMGX_RC AMGX_API AMGX_reset_signal_handler();
 
 AMGX_RC AMGX_API AMGX_register_print_callback
 (AMGX_print_callback func);
+
+AMGX_RC AMGX_API AMGX_get_async_free_to_pool_flag
+(int *ptr);
+
+AMGX_RC AMGX_API AMGX_set_async_free_to_pool_flag
+(int flag);
 
 /* Config */
 AMGX_RC AMGX_API AMGX_config_create
@@ -593,6 +613,72 @@ AMGX_RC AMGX_API AMGX_matrix_check_symmetry
 AMGX_RC AMGX_matrix_check_diag_dominant
 (const AMGX_matrix_handle mtx, 
  int* diag_dominant);
+
+/*********************************************************
+ * C-API zero-copy
+ *********************************************************/
+
+AMGX_RC AMGX_API AMGX_ZC_vector_resize
+(AMGX_vector_handle vec,
+ size_t newSize);
+
+AMGX_RC AMGX_API AMGX_ZC_vector_get_size
+(AMGX_vector_handle vec,
+ size_t *size);
+
+AMGX_RC AMGX_API AMGX_ZC_vector_get_capacity
+(AMGX_vector_handle vec,
+ size_t *capacity);
+
+AMGX_RC AMGX_API AMGX_ZC_vector_get_data_ptr
+(AMGX_vector_handle vec,
+ void **dataPtr);
+
+AMGX_RC AMGX_API AMGX_ZC_vector_shrink_to_fit
+(AMGX_vector_handle vec);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_resize
+(AMGX_matrix_handle mtx,
+ AMGX_MATRIX_DATA_VECTOR dataTag,
+ size_t newSize);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_size
+(AMGX_matrix_handle mtx,
+ AMGX_MATRIX_DATA_VECTOR dataTag,
+ size_t *size);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_capacity
+(AMGX_matrix_handle mtx,
+ AMGX_MATRIX_DATA_VECTOR dataTag,
+ size_t *capacity);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_ptr
+(AMGX_matrix_handle mtx,
+ AMGX_MATRIX_DATA_VECTOR dataTag,
+ void **dataPtr);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_shrink_to_fit
+(AMGX_matrix_handle mtx,
+ AMGX_MATRIX_DATA_VECTOR dataTag);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_initialize
+(AMGX_matrix_handle mtx);
+
+AMGX_RC AMGX_API AMGX_ZC_matrix_finalize
+(AMGX_matrix_handle mtx,
+ int block_dimx,
+ int block_dimy);
+
+AMGX_RC AMGX_API AMGX_ZC_vector_finalize_bind
+(AMGX_vector_handle vec,
+ const AMGX_matrix_handle mtx);
+
+AMGX_RC AMGX_API AMGX_ZC_solver_solve
+(AMGX_solver_handle slv,
+ AMGX_vector_handle rhs,
+ AMGX_vector_handle sol,
+ int initializeSolWithZero);
+
 
 /*********************************************************
  * C-API deprecated

--- a/include/distributed/distributed_manager.h
+++ b/include/distributed/distributed_manager.h
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2011 - 2024 NVIDIA CORPORATION. All Rights Reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// SPDX-FileCopyrightText: Portions Copyright 2024 Siemens and/or its affiliates
+//
+// November 2024 modified by Siemens and/or its affiliates by adding zero-copy interface
 
 #pragma once
 
@@ -386,6 +390,7 @@ template <typename TConfig> class DistributedManagerBase
         void uploadMatrix(int n, int nnz, int block_dimx, int block_dimy, const int *row_ptrs, const int *col_indices, const void *data, const void *diag_data, Matrix<TConfig> &A);
 
         void updateMapsReorder();
+        void updateMapsNoReorder();
 
         void initializeUploadReorderAll(int n, int nnz, int block_dimx, int block_dimy, const int *row_ptrs, const int *col_indices, const void *data, const void *diag_data, Matrix<TConfig> &A);
 

--- a/include/global_thread_handle.h
+++ b/include/global_thread_handle.h
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2013 - 2024 NVIDIA CORPORATION. All Rights Reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// SPDX-FileCopyrightText: Portions Copyright 2024 Siemens and/or its affiliates
+//
+// November 2024 modified by Siemens and/or its affiliates by adding zero-copy interface
 
 #pragma once
 
@@ -179,6 +183,7 @@ void expandDeviceMemoryPool(size_t size, size_t max_block_size);
 
 // Do we use async free.
 void setAsyncFreeFlag(bool set);
+bool getAsyncFreeFlag();
 // Do we use device memory pool.
 void setDeviceMemoryPoolFlag(bool set);
 // Define the scaling factor.

--- a/src/amgx_c.cu
+++ b/src/amgx_c.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2011 - 2024 NVIDIA CORPORATION. All Rights Reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// SPDX-FileCopyrightText: Portions Copyright 2024 Siemens and/or its affiliates
+//
+// November 2024 modified by Siemens and/or its affiliates by adding zero-copy interface
 
 #ifdef _WIN32
 #ifndef AMGX_API_EXPORTS
@@ -3784,6 +3788,22 @@ extern "C" {
         return AMGX_RC_OK;
     }
 
+    AMGX_RC AMGX_get_async_free_to_pool_flag(int *ptr)
+    {
+        nvtxRange nvrf(__func__);
+
+        *ptr = amgx::memory::getAsyncFreeFlag();
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_set_async_free_to_pool_flag(int flag)
+    {
+        nvtxRange nvrf(__func__);
+
+        amgx::memory::setAsyncFreeFlag(flag);
+        return AMGX_RC_OK;
+    }
+
     AMGX_RC AMGX_install_signal_handler()
     {
         nvtxRange nvrf(__func__);
@@ -5312,4 +5332,469 @@ extern "C" {
         return ((ResourceW *)rsc)->wrapped().use_count();
     }
 
+    AMGX_RC AMGX_API AMGX_ZC_vector_resize(AMGX_vector_handle vec, size_t newSize)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec)->resize(newSize); \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_vector_get_size(AMGX_vector_handle vec, size_t *size)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            *size = get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec)->size(); \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_vector_get_capacity(AMGX_vector_handle vec, size_t *capacity)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            *capacity = get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec)->capacity(); \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_vector_get_data_ptr(AMGX_vector_handle vec, void **dataPtr)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            *dataPtr = (void*)get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec)->raw(); \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_vector_shrink_to_fit(AMGX_vector_handle vec)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec)->shrink_to_fit(); \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_resize(AMGX_matrix_handle mtx, AMGX_MATRIX_DATA_VECTOR dataTag, size_t newSize)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            switch(dataTag) { \
+                case(AMGX_MATRIX_ROW_OFFSETS): { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->row_offsets.resize(newSize); break; } \
+                case(AMGX_MATRIX_COL_INDICES): { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->col_indices.resize(newSize); break; } \
+                case(AMGX_MATRIX_VALUES):      { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->values.resize(newSize);      break; } \
+            } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_size(AMGX_matrix_handle mtx, AMGX_MATRIX_DATA_VECTOR dataTag, size_t *size)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            switch(dataTag) { \
+                case(AMGX_MATRIX_ROW_OFFSETS): { *size = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->row_offsets.size(); break; } \
+                case(AMGX_MATRIX_COL_INDICES): { *size = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->col_indices.size(); break; } \
+                case(AMGX_MATRIX_VALUES):      { *size = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->values.size();      break; } \
+            } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_capacity(AMGX_matrix_handle mtx, AMGX_MATRIX_DATA_VECTOR dataTag, size_t *capacity)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            switch(dataTag) { \
+                case(AMGX_MATRIX_ROW_OFFSETS): { *capacity = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->row_offsets.capacity(); break; } \
+                case(AMGX_MATRIX_COL_INDICES): { *capacity = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->col_indices.capacity(); break; } \
+                case(AMGX_MATRIX_VALUES):      { *capacity = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->values.capacity();      break; } \
+            } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_get_ptr(AMGX_matrix_handle mtx, AMGX_MATRIX_DATA_VECTOR dataTag, void **dataPtr)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            switch(dataTag) { \
+                case(AMGX_MATRIX_ROW_OFFSETS): { *dataPtr = (void*)get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->row_offsets.raw(); break; } \
+                case(AMGX_MATRIX_COL_INDICES): { *dataPtr = (void*)get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->col_indices.raw(); break; } \
+                case(AMGX_MATRIX_VALUES):      { *dataPtr = (void*)get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->values.raw();      break; } \
+            } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_data_vec_shrink_to_fit(AMGX_matrix_handle mtx, AMGX_MATRIX_DATA_VECTOR dataTag)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+            switch(dataTag) { \
+                case(AMGX_MATRIX_ROW_OFFSETS): { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->row_offsets.shrink_to_fit(); break; } \
+                case(AMGX_MATRIX_COL_INDICES): { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->col_indices.shrink_to_fit(); break; } \
+                case(AMGX_MATRIX_VALUES):      { get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx)->values.shrink_to_fit();      break; } \
+            } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_initialize(AMGX_matrix_handle mtx)
+    {
+        // these calls have to happen here and not only in AMGX_ZC_matrix_finalize,
+        // they resize and modify the row_offsets, col_indices, values arrays
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+                typedef typename TemplateMode<CASE>::Type TConfig; \
+                typedef CWrapHandle<AMGX_matrix_handle, Matrix<TConfig>> MatrixW; \
+                MatrixW wrapA(mtx); \
+                Matrix<TConfig>& A = *wrapA.wrapped(); \
+                A.set_initialized(0); \
+                A.delProps(amgx::COO); \
+                A.addProps(amgx::CSR); \
+                A.setColsReorderedByColor(false); \
+                A.delProps(amgx::DIAG); \
+        } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_matrix_finalize(AMGX_matrix_handle mtx, int block_dimx, int block_dimy)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_matrix_handle>(mtx);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+                typedef typename TemplateMode<CASE>::Type TConfig; \
+                typedef CWrapHandle<AMGX_matrix_handle, Matrix<TConfig>> MatrixW; \
+                MatrixW wrapA(mtx); \
+                Matrix<TConfig>& A = *wrapA.wrapped(); \
+                A.set_initialized(0); \
+                A.set_block_dimx(block_dimx); \
+                A.set_block_dimy(block_dimy); \
+                if (A.manager == NULL) \
+                { \
+                    int const nRows = A.row_offsets.size() - 1; \
+                    int const nnz   = A.col_indices.size(); \
+                    A.resize(nRows, nRows, nnz, block_dimx, block_dimy); \
+                    A.set_initialized(1); \
+                } \
+                else \
+                { \
+                    A.getManager()->updateMapsNoReorder(); \
+                } \
+        } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_vector_finalize_bind(AMGX_vector_handle vec, const AMGX_matrix_handle mtx)
+    {
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(vec);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+                auto A = get_mode_object_from<CASE,Matrix,AMGX_matrix_handle>(mtx); \
+                auto v = get_mode_object_from<CASE,Vector,AMGX_vector_handle>(vec); \
+                v->set_block_dimx(1); \
+                v->set_block_dimy(A->get_block_dimy()); \
+                if (auto manager = A->getManager()) \
+                { \
+                    v->setManager(*manager); \
+                } \
+            } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
+
+    AMGX_RC AMGX_API AMGX_ZC_solver_solve(AMGX_solver_handle solver, AMGX_vector_handle rhs, AMGX_vector_handle sol, int initializeSolWithZero)
+    {
+        Resources *resources;
+        AMGX_CHECK_API_ERROR(getAMGXerror(getResourcesFromSolverHandle(solver, &resources)), NULL);
+
+        AMGX_ERROR rc = AMGX_OK;
+
+        AMGX_TRIES()
+        {
+            AMGX_Mode mode = get_mode_from<AMGX_vector_handle>(rhs);
+
+            switch (mode)
+            {
+    #define AMGX_CASE_LINE(CASE) case CASE: { \
+                auto rhsV = get_mode_object_from<CASE,Vector,AMGX_vector_handle>(rhs); \
+                auto solV = get_mode_object_from<CASE,Vector,AMGX_vector_handle>(sol); \
+                if (rhsV->getManager() != NULL) \
+                { \
+                    rhsV->dirtybit = 0; \
+                    solV->dirtybit = initializeSolWithZero ? 0 : 1; \
+                } \
+                if (initializeSolWithZero) \
+                { \
+                    typedef TemplateMode<CASE>::Type T_Config; \
+                    amgx::thrust::fill(solV->begin(), solV->end(), types::util<typename T_Config::VecPrec>::get_zero()); \
+                } \
+                rc = solve_with<CASE,AMG_Solver,Vector>(solver, rhs, sol, resources, initializeSolWithZero); \
+                AMGX_CHECK_API_ERROR(rc, resources); \
+                if (solV->getManager() != NULL) \
+                { \
+                    solV->getManager()->exchange_halo(*solV, solV->tag); \
+                } \
+                } \
+            break;
+                    AMGX_FORALL_BUILDS(AMGX_CASE_LINE)
+                    AMGX_FORCOMPLEX_BUILDS(AMGX_CASE_LINE)
+    #undef AMGX_CASE_LINE
+
+                default:
+                    AMGX_CHECK_API_ERROR(AMGX_ERR_BAD_MODE, NULL);
+            }
+        }
+
+        AMGX_CATCHES(rc)
+        AMGX_CHECK_API_ERROR(rc, NULL)
+        return AMGX_RC_OK;
+    }
 }//extern "C"

--- a/src/global_thread_handle.cu
+++ b/src/global_thread_handle.cu
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2013 - 2024 NVIDIA CORPORATION. All Rights Reserved.
 //
 // SPDX-License-Identifier: BSD-3-Clause
+//
+// SPDX-FileCopyrightText: Portions Copyright 2024 Siemens and/or its affiliates
+//
+// November 2024 modified by Siemens and/or its affiliates by adding zero-copy interface
 
 #include <global_thread_handle.h>
 #include <iostream>
@@ -688,6 +692,12 @@ void setAsyncFreeFlag(bool set)
 {
     MemoryManager &manager = MemoryManager::get_instance();
     manager.m_use_async_free = set;
+}
+
+bool getAsyncFreeFlag()
+{
+    MemoryManager &manager = MemoryManager::get_instance();
+    return manager.m_use_async_free;
 }
 
 void setDeviceMemoryPoolFlag(bool set)


### PR DESCRIPTION
This PR adds a zero-copy mode to the C-API. This allows the user to directly assemble matrices into AmgX, thus avoiding duplicate copies of the matrix data in memory and skipping the reordering of that data that would happen in the normal C-API upload routines. The user takes over responsibility for making sure the matrix layout matches what is used by AmgX internally, i.e. the ordering of rows must conform to the AmgX standard (interior, boundary, halo rows).

In the current implementation, there are additional requirements:
 * (block-)CSR format with embedded diagonals that are placed first in every row only
 * in parallel, halo rows in the input data must contain at least diagonal entries

These additional requirements are not fundamental and the ZC interface could naturally be extended to not depend on them, I did not do so because this is our use case and therefore the only tested configuration.

Additionally, I only tested it with AGGREGATION AMG, but I see no reason why it would not work with CLASSICAL too.

Finally, all data should reside on the GPU as this is completely untested with host matrices.

A zero-copy matrix upload works like this:
  * an AmgX-matrix is created as usual with AMGX_matrix_create
  * AMGX_ZC_matrix_initialize is called on it
  * row-offsets, columns and values are allocated and filled using AMGX_ZC_matrix_data_vec_resize/get_ptr
  * in parallel, communication tables are supplied via the standard AMGX_matrix_comm_from_maps
  * AMGX_ZC_matrix_finalize is called

Similarly, vectors can be interfaced with in a zero-copy-manner too:
  * a vector is created as usual with AMGX_vector_create
  * the vectors data can be allocated/accessed with AMGX_ZC_vector_resize/get_ptr
  * after the matrix is finalized, vectors are bound with AMGX_ZC_vector_finalize_bind (instead of AMGX_vector_bind)

When solving for ZC right-hand side and solution vectors, AMGX_ZC_solver_solve replaces the combination of AMGX_vector_upload, AMGX_solver_solve and AMGX_vector_download. In particular, after AMX_ZC_solver_solve, the halo-entries of the solution-vector are consistent i.e. accessing them via the data-pointer gives the correct, global value.

The zero-copy interface also supports releasing the underlying data in AmgX matrices and vectors without entirely destroying these objects via AMGX_ZC_(matrix_data)_vec_resize/shrink_to_fit. This may be useful when matrices with the same sparsity structure are created repeatedly and the user wants to keep the GPU memory high-water mark down, the behavior of the AmgX memory pool can be queried and changed with AMGX_get/set_async_free_to_pool_flag to support this.