### PR TITLE
Fix CUDA 13.3 CCCL compatibility

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -4,6 +4,26 @@
 
 #pragma once
 
+#include <thrust/version.h>
+
+// CCCL 3 removed the legacy thrust::tuple API in favor of cuda::std::tuple.
+// Keep the existing wrapped Thrust namespace usable by AMGX and CUSP.
+#if THRUST_MAJOR_VERSION >= 3
+#include <cuda/std/tuple>
+namespace amgx
+{
+namespace thrust
+{
+using ::cuda::std::get;
+using ::cuda::std::make_tuple;
+using ::cuda::std::tuple;
+using ::cuda::std::tuple_size;
+}
+}
+#else
+#include <thrust/tuple.h>
+#endif
+
 #ifdef _WIN32
 #pragma warning (push)
 #pragma warning (disable : 4244 4267 4521)
@@ -163,4 +183,3 @@ struct TemplateMode
 };
 
 }//namespace amgx
-

--- a/include/cusp/detail/device/conversion.h
+++ b/include/cusp/detail/device/conversion.h
@@ -21,7 +21,7 @@
 #include <thrust/scan.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
-#include <thrust/tuple.h>
+#include <basic_types.h>
 
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -831,4 +831,3 @@ void ell_to_hyb(const Matrix1& src, Matrix2& dst)
 } // end namespace device
 } // end namespace detail
 } // end namespace cusp
-

--- a/include/cusp/gallery/stencil.inl
+++ b/include/cusp/gallery/stencil.inl
@@ -5,7 +5,7 @@
 #include <cusp/copy.h>
 #include <cusp/dia_matrix.h>
 
-#include <thrust/tuple.h>
+#include <basic_types.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/count.h>
@@ -195,4 +195,3 @@ void generate_matrix_from_stencil(      MatrixType& matrix,
                             
 } // end namespace gallery
 } // end namespace cusp
-


### PR DESCRIPTION
This MR fixes AMGX builds with CUDA 13.3 CCCL, where the legacy thrust::tuple API and <thrust/tuple.h> are no longer available.

Changes:

* Adds a guarded compatibility layer in include/basic_types.h.
* For CCCL/Thrust 3+, maps AMGX’s wrapped amgx::thrust::{tuple,get,make_tuple,tuple_size} usage to cuda::std.
* Keeps the old <thrust/tuple.h> path for older CUDA/Thrust versions.
* Replaces direct <thrust/tuple.h> includes in CUSP headers with basic_types.h.