### PR TITLE
Fix complex GMRES inner products

### DIFF
--- a/src/blas.cu
+++ b/src/blas.cu
@@ -650,7 +650,7 @@ typename Vector::value_type dotc(const Vector &a, const Vector &b, int offset, i
         const value_type *a_raw = a.raw() + a_first;
         const value_type *b_raw = b.raw() + b_first;
         value_type result;
-        Cublas::dot(size, a_raw, 1, b_raw, 1, &result);
+        Cublas::dotc(size, a_raw, 1, b_raw, 1, &result);
         cudaCheckError();
         return result;
     }
@@ -684,7 +684,7 @@ typename Vector::value_type dotc(const Vector &a, const Vector &b, int offseta, 
         const value_type *a_raw = a.raw() + a_first;
         const value_type *b_raw = b.raw() + b_first;
         value_type result;
-        Cublas::dot(size, a_raw, 1, b_raw, 1, &result);
+        Cublas::dotc(size, a_raw, 1, b_raw, 1, &result);
         cudaCheckError();
         return result;
     }

--- a/src/solvers/gmres_solver.cu
+++ b/src/solvers/gmres_solver.cu
@@ -327,7 +327,7 @@ GMRES_Solver<T_Config>::solve_iteration( VVector &b, VVector &x, bool xIsZero )
     for ( int k = 0; k <= i; ++k )
     {
         //  H(k,i) = <V(i+1),V(k)>    //
-        m_H(k, i) = dot(A, m_V_vectors[i + 1], m_V_vectors[k]);
+        m_H(k, i) = dot(A, m_V_vectors[k], m_V_vectors[i + 1]);
         // V(i+1) -= H(k, i) * V(k)  //
         axpy( m_V_vectors[k], m_V_vectors[i + 1], types::util<ValueTypeB>::invert(m_H(k, i)), offset, size );
     }


### PR DESCRIPTION
## Summary

Fix the complex-valued inner products used by device code and GMRES Arnoldi orthogonalization.

Fixes #377

## Root cause

The device implementation of `dotc(...)` in `src/blas.cu` calls `Cublas::dot(...)`.

For complex double precision, this maps to the unconjugated `cublasZdotu`, while `dotc(x, y)` is expected to compute the Hermitian inner product `x^H y`.

After restoring the correct `dotc` semantics, the GMRES Modified Gram-Schmidt projection also needs its arguments swapped. The current expression computes `w^H v_k`, whereas Arnoldi orthogonalization requires `v_k^H w`.

## Changes

- Use `Cublas::dotc(...)` in the two device implementations of `dotc(...)`.
- Change the GMRES projection argument order from `dot(w, v_k)` to `dot(v_k, w)`.

## Testing

Tested using the 3x3 complex reproducer from #377 with:

- AMGX mode: `dZZI`
- GMRES restart: `10`
- No preconditioner
- Same matrix, RHS, initial guess, and solver configuration

Results:

| | Original v2.5.0 | Patched |
|---|---:|---:|
| Total iterations | 500 | 3 |
| Final residual | `2.955383e-05` | `4.981581e-16` |
| Status | Did not converge | Converged |

The same reproducer was also tested after applying the patch to the current `main` branch.

Full reproduction details and logs are available in #377.